### PR TITLE
Analyze Feature Files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 npm test                # Run all tests (Cucumber.js, suppresses stderr)
-npm run test:debug      # Run all tests with full output
-npm run test:cucumber   # Run with explicit ts-node loader
-npm run build           # Full build: clean → tsc → vite → dts-bundle-generator → copy
+npm run test:debug      # Run all tests with full output (use when debugging failures)
+npm run test:cucumber   # Run with default Cucumber profile
+npm run test:ci         # Run with CI profile
+npm run build           # Full build: clean → tsc → rolldown → dts-bundle-generator → copy
 npm run lint            # ESLint
 npm run format          # Prettier
 ```
-
-There is no way to run a single test file. Tests are Cucumber feature files in `features/` and run via `cucumber-js`. To run a subset, use Cucumber tags or modify the feature files temporarily.
 
 ## Architecture
 
@@ -46,9 +45,66 @@ builder<State>().statement(str | fn) → .dependencies?(deps) → .step(fn) → 
 - `src/builderTypeUtils.ts` — TypeScript utility types driving the builder's type safety
 - `src/utils.ts` — `typeCoercer()` for string→typed conversion, `requireFrom{Given,When,Then}()` for runtime dep validation
 
-### Testing Pattern
+### Testing
 
 Tests use Cucumber.js itself (self-testing). Feature files in `features/` with step definitions in `features/steps/` exercise the library. Type-safety tests in `test/` use `@ts-expect-error` annotations — they validate at `tsc` compile time, not at runtime.
+
+#### Test Scripts
+
+| Script | Profile | Description |
+|---|---|---|
+| `npm test` | `all` | Run all tests. Suppresses stderr (`2> /dev/null`) for clean output. Use this for normal development. |
+| `npm run test:debug` | `all` | Run all tests with full output (stderr included). Use this when a test fails and you need stack traces or error details. |
+| `npm run test:cucumber` | `default` | Run tests using the `default` Cucumber profile. Same paths as `all`, but does not set `PORT` or `LOG_LEVEL`. |
+| `npm run test:ci` | `ci` | CI-oriented profile. Does not import `src/**/*.ts` (only step defs). Enables `publish`. |
+
+All profiles run with `parallel: 1` and use `tsx` as the TypeScript loader via `NODE_OPTIONS='--import tsx'`.
+
+There is no way to run a single test file. To run a subset, use Cucumber tags or modify the feature files temporarily.
+
+#### Analyzer Tests
+
+The analyzer has its own test suite under `features/analyzer/` that tests the `analyze()` API against fixture files. The fixtures are **data** — they are read by the analyzer's extractor and parser, not executed by Cucumber.
+
+```
+features/analyzer/
+  analyzer.feature                ← Test scenarios (run by Cucumber)
+  fixtures/
+    steps.ts                      ← Fixture step definitions (read by extractor as data)
+    valid-no-deps.feature         ← Fixture feature files (read by parser as data)
+    valid-deps.feature
+    missing-given-dep.feature
+    ...
+```
+
+The `cucumber.mjs` config uses non-recursive path globs (`./features/*.feature`, `./features/analyzer/*.feature`) to ensure fixture files in `features/analyzer/fixtures/` are never executed as tests.
+
+Step definitions in `features/steps/analyzerSteps.ts` provide these steps:
+
+- `Given step definitions from {string}` — sets the fixture step file (relative to `fixtures/`)
+- `Given a feature file {string}` — sets the fixture feature file (relative to `fixtures/`)
+- `When I analyze the files` — calls `analyze()` with the configured files
+- `Then there should be no errors` — asserts zero errors
+- `Then there should be {int} error/errors` — asserts exact error count
+- `Then an error should mention {string}` — asserts an error message contains the substring
+
+#### Adding New Analyzer Tests
+
+1. **If you need new step definition patterns**, add builder calls to `features/analyzer/fixtures/steps.ts`. This file is only parsed by the TypeScript AST extractor — it is never executed, but it must be valid TypeScript that compiles.
+
+2. **Create a fixture feature file** in `features/analyzer/fixtures/` that uses the step expressions defined in `steps.ts`. This file is parsed by the Gherkin parser as data — Cucumber never runs it.
+
+3. **Add a scenario** to `features/analyzer/analyzer.feature`:
+   ```gherkin
+   Scenario: Description of what you're testing
+     Given step definitions from "steps.ts"
+     Given a feature file "your-new-fixture.feature"
+     When I analyze the files
+     Then there should be no errors
+   ```
+   The Background already provides `step definitions from "steps.ts"`, so you only need the `Given a feature file` line in each scenario.
+
+4. **Run `npm run test:debug`** to verify. Use `test:debug` instead of `npm test` so you can see error details if something fails.
 
 ### Build Output
 

--- a/cucumber.mjs
+++ b/cucumber.mjs
@@ -6,6 +6,10 @@ const defaultProfile = {
     "usage:./reports/cucumber/usage.txt",
   ],
   parallel: 1,
+  paths: [
+    "./features/*.feature",
+    "./features/analyzer/*.feature",
+  ],
   import: [
     "./features/steps/**/*.ts",
     "./features/steps/*.ts",
@@ -29,7 +33,6 @@ const ciProfile = {
 
 const all = {
   ...defaultProfile,
-  paths: ["./features"],
 };
 
 export { ciProfile as ci, all };

--- a/dts-bundle-generator.config.cjs
+++ b/dts-bundle-generator.config.cjs
@@ -1,8 +1,16 @@
 const config = {
+  compilationOptions: {
+    preferredConfigPath: "./tsconfig.json",
+  },
   entries: [
     {
       filePath: "./src/index.ts",
       outFile: "./build/dist/index.d.ts",
+      noCheck: false,
+    },
+    {
+      filePath: "./src/analyzer/index.ts",
+      outFile: "./build/dist/analyzer.d.ts",
       noCheck: false,
     },
   ],

--- a/features/TESTING.md
+++ b/features/TESTING.md
@@ -1,0 +1,100 @@
+# Testing
+
+All tests use Cucumber.js in a self-testing pattern: feature files in `features/` with step definitions in `features/steps/` exercise the library.
+
+## Test Scripts
+
+| Script                  | Profile   | Description                                                                                                         |
+| ----------------------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
+| `npm test`              | `all`     | Run all tests. Suppresses stderr for clean output. Use for normal development.                                      |
+| `npm run test:debug`    | `all`     | Run all tests with full output (stderr included). Use when a test fails and you need stack traces or error details. |
+| `npm run test:cucumber` | `default` | Same paths as `all`, but does not set `PORT` or `LOG_LEVEL`.                                                        |
+| `npm run test:ci`       | `ci`      | CI-oriented profile. Does not import `src/**/*.ts` (only step defs). Enables `publish`.                             |
+
+All profiles run with `parallel: 1` and use `tsx` as the TypeScript loader.
+
+There is no way to run a single test file. To run a subset, use Cucumber tags or modify the feature files temporarily.
+
+## Directory Structure
+
+```
+features/
+  basic.feature                   ← Builder pattern tests (variables, deps, state)
+  exported.feature                ← Re-exported builder tests
+  steps/
+    commonSteps.ts                ← Step defs for basic.feature
+    exportedSteps.ts              ← Step defs for exported.feature
+    analyzerSteps.ts              ← Step defs for analyzer tests
+    world.ts                      ← World state types
+  analyzer/
+    analyzer.feature              ← Analyzer test scenarios (run by Cucumber)
+    fixtures/
+      steps.ts                    ← Fixture step definitions (data, NOT run by Cucumber)
+      valid-no-deps.feature       ← Fixture feature files (data, NOT run by Cucumber)
+      valid-deps.feature
+      ...
+```
+
+## Builder Tests
+
+`basic.feature` and `exported.feature` test the core builder pattern — step registration, variable extraction, dependency resolution, and state merging. Their step definitions in `features/steps/` use the builders directly and assert on the resulting world state.
+
+Type-safety tests in `test/` use `@ts-expect-error` annotations and validate at `tsc` compile time, not at runtime.
+
+## Analyzer Tests
+
+The analyzer test suite under `features/analyzer/` tests the `analyze()` API against fixture files. The key distinction: **fixture files are data, not tests**. The analyzer's extractor reads `fixtures/steps.ts` as a TypeScript AST, and the parser reads `fixtures/*.feature` as Gherkin data. Cucumber never executes them.
+
+The `cucumber.mjs` config uses non-recursive path globs (`./features/*.feature`, `./features/analyzer/*.feature`) so fixture files in `features/analyzer/fixtures/` are excluded from Cucumber's test discovery.
+
+### Available Steps
+
+Step definitions in `features/steps/analyzerSteps.ts` provide:
+
+| Step                                      | Purpose                                                |
+| ----------------------------------------- | ------------------------------------------------------ |
+| `Given step definitions from {string}`    | Set the fixture step file (relative to `fixtures/`)    |
+| `Given a feature file {string}`           | Set the fixture feature file (relative to `fixtures/`) |
+| `When I analyze the files`                | Call `analyze()` with the configured files             |
+| `Then there should be no errors`          | Assert zero errors in diagnostics                      |
+| `Then there should be {int} error/errors` | Assert exact error count                               |
+| `Then an error should mention {string}`   | Assert an error message contains the substring         |
+
+### Adding New Analyzer Tests
+
+1. **Add step definition patterns** (if needed) to `features/analyzer/fixtures/steps.ts`. This file must be valid TypeScript that compiles, but it is never executed — only parsed by the AST extractor.
+
+2. **Create a fixture feature file** in `features/analyzer/fixtures/` using the step expressions from `steps.ts`. This file is parsed by the Gherkin parser as data.
+
+3. **Add a scenario** to `features/analyzer/analyzer.feature`:
+
+   ```gherkin
+   Scenario: Description of what you're testing
+     Given a feature file "your-new-fixture.feature"
+     When I analyze the files
+     Then there should be no errors
+   ```
+
+   The Background already provides `Given step definitions from "steps.ts"`, so you only need the `Given a feature file` line in each scenario.
+
+4. **Run `npm run test:debug`** to verify. Use `test:debug` instead of `npm test` so you can see error details if something fails.
+
+### Fixture Step Definitions
+
+`features/analyzer/fixtures/steps.ts` contains builder calls covering these patterns:
+
+| Expression                    | Type  | Dependencies              | Produces  |
+| ----------------------------- | ----- | ------------------------- | --------- |
+| `a user`                      | given | none                      | `user`    |
+| `a user named {string}`       | given | none                      | `user`    |
+| `an account`                  | given | none                      | `account` |
+| `I started`                   | given | none                      | (nothing) |
+| `I save the user`             | when  | `given.user: required`    | `user`    |
+| `I delete the account`        | when  | `given.account: required` | `result`  |
+| `I got here`                  | when  | none                      | (nothing) |
+| `everything was good`         | then  | none                      | (nothing) |
+| `there is a user`             | then  | `when.user: required`     | (nothing) |
+| `the user's name is {string}` | then  | `when.user: required`     | (nothing) |
+| `the account might exist`     | then  | `given.account: optional` | (nothing) |
+
+When adding new patterns, add them to this file and they'll be available to all fixture feature files.

--- a/features/analyzer/analyzer.feature
+++ b/features/analyzer/analyzer.feature
@@ -1,0 +1,50 @@
+Feature: Analyzer dependency verification
+
+  Background:
+    Given step definitions from "steps.ts"
+
+  # --- Passing scenarios ---
+
+  Scenario: No dependencies produces no errors
+    Given a feature file "valid-no-deps.feature"
+    When I analyze the files
+    Then there should be no errors
+
+  Scenario: Satisfied required dependencies produce no errors
+    Given a feature file "valid-deps.feature"
+    When I analyze the files
+    Then there should be no errors
+
+  Scenario: Variables with satisfied dependencies produce no errors
+    Given a feature file "valid-variables.feature"
+    When I analyze the files
+    Then there should be no errors
+
+  Scenario: Optional dependencies not produced produce no errors
+    Given a feature file "valid-optional-deps.feature"
+    When I analyze the files
+    Then there should be no errors
+
+  Scenario: And/But keywords resolve correctly with satisfied deps
+    Given a feature file "valid-and-but-keywords.feature"
+    When I analyze the files
+    Then there should be no errors
+
+  # --- Failing scenarios ---
+
+  Scenario: Missing required given dependency reports an error
+    Given a feature file "missing-given-dep.feature"
+    When I analyze the files
+    Then there should be 1 errors
+    And an error should mention "given.user"
+
+  Scenario: Missing required when dependency reports an error
+    Given a feature file "missing-when-dep.feature"
+    When I analyze the files
+    Then there should be 1 errors
+    And an error should mention "when.user"
+
+  Scenario: Multiple missing dependencies reports multiple errors
+    Given a feature file "missing-multiple-deps.feature"
+    When I analyze the files
+    Then there should be 2 errors

--- a/features/analyzer/fixtures/missing-given-dep.feature
+++ b/features/analyzer/fixtures/missing-given-dep.feature
@@ -1,0 +1,5 @@
+Feature: Missing given dependency
+
+  Scenario: When step needs given.user but nothing produces it
+    When I save the user
+    Then everything was good

--- a/features/analyzer/fixtures/missing-multiple-deps.feature
+++ b/features/analyzer/fixtures/missing-multiple-deps.feature
@@ -1,0 +1,6 @@
+Feature: Multiple missing dependencies
+
+  Scenario: Multiple steps with missing deps
+    When I save the user
+    When I delete the account
+    Then there is a user

--- a/features/analyzer/fixtures/missing-when-dep.feature
+++ b/features/analyzer/fixtures/missing-when-dep.feature
@@ -1,0 +1,5 @@
+Feature: Missing when dependency
+
+  Scenario: Then step needs when.user but nothing produces it
+    Given a user
+    Then there is a user

--- a/features/analyzer/fixtures/steps.ts
+++ b/features/analyzer/fixtures/steps.ts
@@ -1,0 +1,101 @@
+import { givenBuilder } from "../../../src/given";
+import { whenBuilder } from "../../../src/when";
+import { thenBuilder } from "../../../src/then";
+
+type GivenState = {
+  user: { type: string; token: string };
+  account: { id: string };
+};
+type WhenState = {
+  user: { type: string; token: string; saved: boolean };
+  result: { success: boolean };
+};
+type ThenState = Record<string, never>;
+
+// --- No dependency steps --- //
+
+givenBuilder<GivenState>()
+  .statement("I started")
+  .step(() => ({}))
+  .register();
+
+whenBuilder<GivenState, WhenState>()
+  .statement("I got here")
+  .step(() => ({}))
+  .register();
+
+thenBuilder<GivenState, WhenState, ThenState>()
+  .statement("everything was good")
+  .step(() => {})
+  .register();
+
+// --- Steps that produce state --- //
+
+givenBuilder<GivenState>()
+  .statement("a user")
+  .step(() => {
+    return {
+      user: { type: "person", token: "abc" },
+    };
+  })
+  .register();
+
+givenBuilder<GivenState>()
+  .statement((name: string) => `a user named ${name}`)
+  .step(({ variables: [name] }) => {
+    return {
+      user: { type: "person", token: name },
+    };
+  })
+  .register();
+
+givenBuilder<GivenState>()
+  .statement("an account")
+  .step(() => {
+    return {
+      account: { id: "acct-1" },
+    };
+  })
+  .register();
+
+// --- When steps with dependencies --- //
+
+whenBuilder<GivenState, WhenState>()
+  .statement("I save the user")
+  .dependencies({ given: { user: "required" } })
+  .step(({ given: { user } }) => {
+    return {
+      user: { ...user, saved: true },
+    };
+  })
+  .register();
+
+whenBuilder<GivenState, WhenState>()
+  .statement("I delete the account")
+  .dependencies({ given: { account: "required" } })
+  .step(() => {
+    return {
+      result: { success: true },
+    };
+  })
+  .register();
+
+// --- Then steps with dependencies --- //
+
+thenBuilder<GivenState, WhenState, ThenState>()
+  .statement("there is a user")
+  .dependencies({ when: { user: "required" } })
+  .step(() => {})
+  .register();
+
+thenBuilder<GivenState, WhenState, ThenState>()
+  .statement((name: string) => `the user's name is ${name}`)
+  .dependencies({ when: { user: "required" } })
+  .step(() => {})
+  .register();
+
+thenBuilder<GivenState, WhenState, ThenState>()
+  .statement("the account might exist")
+  .dependencies({ given: { account: "optional" } })
+  .step(() => {})
+  .register();

--- a/features/analyzer/fixtures/valid-and-but-keywords.feature
+++ b/features/analyzer/fixtures/valid-and-but-keywords.feature
@@ -1,0 +1,8 @@
+Feature: And/But keyword resolution
+
+  Scenario: And and But resolve correctly
+    Given a user
+    And an account
+    When I save the user
+    But I delete the account
+    Then there is a user

--- a/features/analyzer/fixtures/valid-deps.feature
+++ b/features/analyzer/fixtures/valid-deps.feature
@@ -1,0 +1,6 @@
+Feature: Satisfied dependencies
+
+  Scenario: Full chain with required deps
+    Given a user
+    When I save the user
+    Then there is a user

--- a/features/analyzer/fixtures/valid-no-deps.feature
+++ b/features/analyzer/fixtures/valid-no-deps.feature
@@ -1,0 +1,6 @@
+Feature: No dependencies
+
+  Scenario: Steps with no dependencies
+    Given I started
+    When I got here
+    Then everything was good

--- a/features/analyzer/fixtures/valid-optional-deps.feature
+++ b/features/analyzer/fixtures/valid-optional-deps.feature
@@ -1,0 +1,6 @@
+Feature: Optional dependencies
+
+  Scenario: Optional dep not produced is fine
+    Given I started
+    When I got here
+    Then the account might exist

--- a/features/analyzer/fixtures/valid-variables.feature
+++ b/features/analyzer/fixtures/valid-variables.feature
@@ -1,0 +1,6 @@
+Feature: Variables with dependencies
+
+  Scenario: Variables and satisfied deps
+    Given a user named "John"
+    When I save the user
+    Then the user's name is "John"

--- a/features/steps/analyzerSteps.ts
+++ b/features/steps/analyzerSteps.ts
@@ -1,0 +1,43 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Given, When, Then } from "@cucumber/cucumber";
+import { expect } from "earl";
+import { analyze, Diagnostic } from "../../src/analyzer/index";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.resolve(__dirname, "../analyzer/fixtures");
+
+let fixtureStepFile: string;
+let fixtureFeatureFile: string;
+let diagnostics: Diagnostic[];
+
+Given("step definitions from {string}", function (fileName: string) {
+  fixtureStepFile = path.join(fixturesDir, fileName);
+});
+
+Given("a feature file {string}", function (fileName: string) {
+  fixtureFeatureFile = path.join(fixturesDir, fileName);
+});
+
+When("I analyze the files", async function () {
+  diagnostics = await analyze({
+    stepFiles: [fixtureStepFile],
+    featureFiles: [fixtureFeatureFile],
+  });
+});
+
+Then("there should be no errors", function () {
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  expect(errors).toHaveLength(0);
+});
+
+Then("there should be {int} error/errors", function (count: number) {
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  expect(errors).toHaveLength(count);
+});
+
+Then("an error should mention {string}", function (substring: string) {
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  const found = errors.some((e) => e.message.includes(substring));
+  expect(found).toEqual(true);
+});

--- a/package.json
+++ b/package.json
@@ -7,9 +7,15 @@
     ".": {
       "import": "./dist/step-forge.js"
     },
+    "./analyzer": {
+      "import": "./dist/analyzer.js"
+    },
     "./dist/": {
       "import": "./dist/"
     }
+  },
+  "bin": {
+    "step-forge-analyze": "./dist/analyzer-cli.js"
   },
   "types": "./dist/index.d.ts",
   "scripts": {
@@ -38,8 +44,19 @@
     "rolldown": "^1.0.0-rc.3",
     "typescript": "^5.7.2"
   },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@cucumber/cucumber": "^12.6.0",
+    "@cucumber/cucumber-expressions": "^18.1.0",
+    "@cucumber/gherkin": "^37.0.1",
+    "@cucumber/messages": "^24.1.0",
     "lodash": "^4.17.21"
   }
 }

--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -1,11 +1,34 @@
 import { defineConfig } from "rolldown";
 
-export default defineConfig({
-  input: "./src/index.ts",
-  output: {
-    file: "./build/dist/step-forge.js",
-    format: "esm",
-    sourcemap: true,
+export default defineConfig([
+  {
+    input: "./src/index.ts",
+    output: {
+      file: "./build/dist/step-forge.js",
+      format: "esm",
+      sourcemap: true,
+    },
+    external: ["@cucumber/cucumber", "lodash"],
   },
-  external: ["@cucumber/cucumber", "lodash"],
-});
+  {
+    input: {
+      analyzer: "./src/analyzer/index.ts",
+      "analyzer-cli": "./src/analyzer/cli.ts",
+    },
+    output: {
+      dir: "./build/dist",
+      format: "esm",
+      sourcemap: true,
+      entryFileNames: "[name].js",
+    },
+    external: [
+      "@cucumber/cucumber",
+      "@cucumber/gherkin",
+      "@cucumber/messages",
+      "@cucumber/cucumber-expressions",
+      "lodash",
+      "typescript",
+      /^node:/,
+    ],
+  },
+]);

--- a/src/analyzer/cli.ts
+++ b/src/analyzer/cli.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { analyze } from "./index.js";
+import type { AnalyzerConfig, Diagnostic } from "./types.js";
+
+function parseArgs(args: string[]): AnalyzerConfig {
+  const config: AnalyzerConfig = {
+    stepFiles: [],
+    featureFiles: [],
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+
+    if ((arg === "--steps" || arg === "-s") && next) {
+      config.stepFiles.push(next);
+      i++;
+    } else if ((arg === "--features" || arg === "-f") && next) {
+      config.featureFiles.push(next);
+      i++;
+    } else if (arg === "--tsconfig" && next) {
+      config.tsConfigPath = next;
+      i++;
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+  }
+
+  return config;
+}
+
+function printUsage() {
+  console.log(`Usage: step-forge-analyze [options]
+
+Options:
+  -s, --steps <glob>      Glob pattern for step definition files (repeatable)
+  -f, --features <glob>   Glob pattern for feature files (repeatable)
+  --tsconfig <path>       Path to tsconfig.json (default: auto-detect)
+  -h, --help              Show this help message
+
+Example:
+  step-forge-analyze --steps "features/steps/**/*.ts" --features "features/**/*.feature"
+`);
+}
+
+function formatDiagnostic(diag: Diagnostic): string {
+  const location = `${diag.file}:${diag.range.startLine}:${diag.range.startColumn}`;
+  return `${location} - ${diag.severity}: ${diag.message}`;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const config = parseArgs(args);
+
+  if (config.stepFiles.length === 0 || config.featureFiles.length === 0) {
+    console.error(
+      "Error: Both --steps and --features are required.\n"
+    );
+    printUsage();
+    process.exit(1);
+  }
+
+  const diagnostics = await analyze(config);
+
+  if (diagnostics.length === 0) {
+    console.log("No issues found.");
+    process.exit(0);
+  }
+
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  const warnings = diagnostics.filter((d) => d.severity === "warning");
+
+  for (const diag of diagnostics) {
+    console.log(formatDiagnostic(diag));
+  }
+
+  console.log(
+    `\nFound ${errors.length} error(s) and ${warnings.length} warning(s).`
+  );
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+// Only run when invoked directly (not when imported by Cucumber or other tools)
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("analyzer-cli.js") ||
+  process.argv[1]?.endsWith("analyzer-cli.ts");
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Analyzer failed:", err);
+    process.exit(1);
+  });
+}

--- a/src/analyzer/gherkinParser.ts
+++ b/src/analyzer/gherkinParser.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs";
+import { GherkinClassicTokenMatcher, Parser, AstBuilder } from "@cucumber/gherkin";
+import * as messages from "@cucumber/messages";
+import { ParsedScenario, ParsedStep } from "./types.js";
+
+type GherkinKeyword = "Given" | "When" | "Then" | "And" | "But";
+
+export function parseFeatureFiles(filePaths: string[]): ParsedScenario[] {
+  const scenarios: ParsedScenario[] = [];
+
+  for (const filePath of filePaths) {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const parsed = parseFeatureContent(content, filePath);
+    scenarios.push(...parsed);
+  }
+
+  return scenarios;
+}
+
+function parseFeatureContent(
+  content: string,
+  filePath: string
+): ParsedScenario[] {
+  const newId = messages.IdGenerator.uuid();
+  const builder = new AstBuilder(newId);
+  const matcher = new GherkinClassicTokenMatcher();
+  const parser = new Parser(builder, matcher);
+
+  const gherkinDocument: messages.GherkinDocument = parser.parse(content);
+  const feature = gherkinDocument.feature;
+  if (!feature) return [];
+
+  // Collect background steps at the feature level
+  const featureBackground: messages.Step[] = [];
+  const scenarios: ParsedScenario[] = [];
+
+  for (const child of feature.children) {
+    if (child.background) {
+      featureBackground.push(...child.background.steps);
+    }
+
+    if (child.scenario) {
+      scenarios.push(
+        ...expandScenario(child.scenario, featureBackground, filePath)
+      );
+    }
+
+    if (child.rule) {
+      // Rules can have their own backgrounds
+      const ruleBackground: messages.Step[] = [...featureBackground];
+      for (const ruleChild of child.rule.children) {
+        if (ruleChild.background) {
+          ruleBackground.push(...ruleChild.background.steps);
+        }
+        if (ruleChild.scenario) {
+          scenarios.push(
+            ...expandScenario(ruleChild.scenario, ruleBackground, filePath)
+          );
+        }
+      }
+    }
+  }
+
+  return scenarios;
+}
+
+function expandScenario(
+  scenario: messages.Scenario,
+  backgroundSteps: messages.Step[],
+  filePath: string
+): ParsedScenario[] {
+  const hasExamples =
+    scenario.examples.length > 0 &&
+    scenario.examples.some((e) => e.tableBody.length > 0);
+
+  if (!hasExamples) {
+    // Regular scenario
+    const bgParsed = convertSteps(backgroundSteps);
+    const scenarioParsed = convertSteps(scenario.steps);
+    const allSteps = resolveEffectiveKeywords([...bgParsed, ...scenarioParsed]);
+
+    return [
+      {
+        name: scenario.name,
+        file: filePath,
+        steps: allSteps,
+      },
+    ];
+  }
+
+  // Scenario Outline — expand with each example row
+  const results: ParsedScenario[] = [];
+  for (const example of scenario.examples) {
+    if (!example.tableHeader || example.tableBody.length === 0) continue;
+    const headers = example.tableHeader.cells.map((c) => c.value);
+
+    for (const row of example.tableBody) {
+      const values = row.cells.map((c) => c.value);
+      const substitution: Record<string, string> = {};
+      headers.forEach((h, i) => {
+        substitution[h] = values[i];
+      });
+
+      const bgParsed = convertSteps(backgroundSteps);
+      const scenarioSteps = convertSteps(scenario.steps).map((step) => ({
+        ...step,
+        text: substituteExampleValues(step.text, substitution),
+      }));
+      const allSteps = resolveEffectiveKeywords([...bgParsed, ...scenarioSteps]);
+
+      results.push({
+        name: `${scenario.name} (${values.join(", ")})`,
+        file: filePath,
+        steps: allSteps,
+      });
+    }
+  }
+
+  return results;
+}
+
+function convertSteps(
+  steps: readonly messages.Step[]
+): Omit<ParsedStep, "effectiveKeyword">[] {
+  return steps.map((step) => ({
+    keyword: normalizeKeyword(step.keyword),
+    text: step.text,
+    line: step.location.line,
+    column: step.location.column ?? 1,
+  }));
+}
+
+function normalizeKeyword(keyword: string): GherkinKeyword {
+  const trimmed = keyword.trim();
+  // Gherkin keywords may include trailing space, e.g. "Given "
+  if (trimmed === "Given") return "Given";
+  if (trimmed === "When") return "When";
+  if (trimmed === "Then") return "Then";
+  if (trimmed === "And") return "And";
+  if (trimmed === "But") return "But";
+  // Fallback: treat as Given (shouldn't happen with valid Gherkin)
+  return "Given";
+}
+
+function resolveEffectiveKeywords(
+  steps: Omit<ParsedStep, "effectiveKeyword">[]
+): ParsedStep[] {
+  let lastEffective: "Given" | "When" | "Then" = "Given";
+
+  return steps.map((step) => {
+    let effectiveKeyword: "Given" | "When" | "Then";
+    if (step.keyword === "And" || step.keyword === "But") {
+      effectiveKeyword = lastEffective;
+    } else {
+      effectiveKeyword = step.keyword as "Given" | "When" | "Then";
+    }
+    lastEffective = effectiveKeyword;
+
+    return {
+      ...step,
+      effectiveKeyword,
+    };
+  });
+}
+
+function substituteExampleValues(
+  text: string,
+  substitution: Record<string, string>
+): string {
+  let result = text;
+  for (const [key, value] of Object.entries(substitution)) {
+    result = result.replace(new RegExp(`<${key}>`, "g"), value);
+  }
+  return result;
+}

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -1,0 +1,77 @@
+import { glob } from "node:fs/promises";
+import * as path from "node:path";
+import { extractStepDefinitions } from "./stepExtractor.js";
+import { parseFeatureFiles } from "./gherkinParser.js";
+import { matchScenarioSteps } from "./stepMatcher.js";
+import { defaultRules, runRules } from "./rules/index.js";
+import type {
+  AnalyzerConfig,
+  AnalysisRule,
+  Diagnostic,
+  StepDefinitionMeta,
+  ParsedScenario,
+  MatchedStep,
+  ParsedStep,
+} from "./types.js";
+
+export type {
+  AnalyzerConfig,
+  AnalysisRule,
+  Diagnostic,
+  StepDefinitionMeta,
+  ParsedScenario,
+  MatchedStep,
+  ParsedStep,
+};
+
+export interface AnalyzeOptions {
+  rules?: AnalysisRule[];
+}
+
+export async function analyze(
+  config: AnalyzerConfig,
+  options?: AnalyzeOptions
+): Promise<Diagnostic[]> {
+  const rules = options?.rules ?? defaultRules;
+
+  // 1. Resolve file globs to paths
+  const stepFilePaths = await resolveGlobs(config.stepFiles);
+  const featureFilePaths = await resolveGlobs(config.featureFiles);
+
+  if (stepFilePaths.length === 0) {
+    return [];
+  }
+  if (featureFilePaths.length === 0) {
+    return [];
+  }
+
+  // 2. Extract step metadata from step files
+  const stepDefinitions = extractStepDefinitions(
+    stepFilePaths,
+    config.tsConfigPath
+  );
+
+  // 3. Parse feature files
+  const scenarios = parseFeatureFiles(featureFilePaths);
+
+  // 4. For each scenario, match steps and run rules
+  const diagnostics: Diagnostic[] = [];
+  for (const scenario of scenarios) {
+    const matchedSteps = matchScenarioSteps(scenario, stepDefinitions);
+    const scenarioDiags = runRules(rules, scenario, matchedSteps);
+    diagnostics.push(...scenarioDiags);
+  }
+
+  return diagnostics;
+}
+
+async function resolveGlobs(patterns: string[]): Promise<string[]> {
+  const files: string[] = [];
+  for (const pattern of patterns) {
+    for await (const file of glob(pattern)) {
+      files.push(path.resolve(file));
+    }
+  }
+  // Deduplicate
+  return [...new Set(files)];
+}

--- a/src/analyzer/rules/dependencyRule.ts
+++ b/src/analyzer/rules/dependencyRule.ts
@@ -1,0 +1,59 @@
+import {
+  AnalysisRule,
+  Diagnostic,
+  MatchedStep,
+  ParsedScenario,
+} from "../types.js";
+
+export const dependencyRule: AnalysisRule = {
+  name: "dependency-check",
+
+  check(
+    scenario: ParsedScenario,
+    matchedSteps: MatchedStep[]
+  ): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+    const produced = {
+      given: new Set<string>(),
+      when: new Set<string>(),
+      then: new Set<string>(),
+    };
+
+    for (const step of matchedSteps) {
+      if (!step.definition) continue;
+
+      const { dependencies, produces, stepType } = step.definition;
+
+      // Check required dependencies
+      for (const phase of ["given", "when", "then"] as const) {
+        for (const [key, requirement] of Object.entries(dependencies[phase])) {
+          if (requirement === "required" && !produced[phase].has(key)) {
+            const available = [...produced[phase]];
+            const availableStr =
+              available.length > 0 ? available.join(", ") : "(none)";
+            diagnostics.push({
+              file: scenario.file,
+              range: {
+                startLine: step.line,
+                startColumn: step.column,
+                endLine: step.line,
+                endColumn: step.column + step.text.length,
+              },
+              severity: "error",
+              message: `Step "${step.text}" requires '${phase}.${key}' but no preceding step produces it. Available ${phase} keys: ${availableStr}. Defined in: ${step.definition.sourceFile}:${step.definition.line}`,
+              rule: "dependency-check",
+              source: "step-forge",
+            });
+          }
+        }
+      }
+
+      // Add produced keys for this step
+      for (const key of produces) {
+        produced[stepType].add(key);
+      }
+    }
+
+    return diagnostics;
+  },
+};

--- a/src/analyzer/rules/index.ts
+++ b/src/analyzer/rules/index.ts
@@ -1,0 +1,17 @@
+import {
+  AnalysisRule,
+  Diagnostic,
+  MatchedStep,
+  ParsedScenario,
+} from "../types.js";
+import { dependencyRule } from "./dependencyRule.js";
+
+export const defaultRules: AnalysisRule[] = [dependencyRule];
+
+export function runRules(
+  rules: AnalysisRule[],
+  scenario: ParsedScenario,
+  matchedSteps: MatchedStep[]
+): Diagnostic[] {
+  return rules.flatMap((rule) => rule.check(scenario, matchedSteps));
+}

--- a/src/analyzer/stepExtractor.ts
+++ b/src/analyzer/stepExtractor.ts
@@ -1,0 +1,432 @@
+import ts from "typescript";
+import { StepDefinitionMeta } from "./types.js";
+
+type StepType = "given" | "when" | "then";
+
+const BUILDER_NAMES: Record<string, StepType> = {
+  givenBuilder: "given",
+  whenBuilder: "when",
+  thenBuilder: "then",
+};
+
+export function extractStepDefinitions(
+  filePaths: string[],
+  tsConfigPath?: string
+): StepDefinitionMeta[] {
+  const configPath =
+    tsConfigPath ?? ts.findConfigFile(process.cwd(), ts.sys.fileExists);
+  let compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    strict: true,
+    esModuleInterop: true,
+  };
+
+  if (configPath) {
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+    if (!configFile.error) {
+      const parsed = ts.parseJsonConfigFileContent(
+        configFile.config,
+        ts.sys,
+        configPath.replace(/[/\\][^/\\]+$/, "")
+      );
+      compilerOptions = parsed.options;
+    }
+  }
+
+  // Ensure noEmit so we don't write files
+  compilerOptions.noEmit = true;
+
+  const program = ts.createProgram(filePaths, compilerOptions);
+  const checker = program.getTypeChecker();
+  const results: StepDefinitionMeta[] = [];
+
+  for (const filePath of filePaths) {
+    const sourceFile = program.getSourceFile(filePath);
+    if (!sourceFile) continue;
+    const fileResults = extractFromSourceFile(sourceFile, checker);
+    results.push(...fileResults);
+  }
+
+  return results;
+}
+
+function extractFromSourceFile(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker
+): StepDefinitionMeta[] {
+  const results: StepDefinitionMeta[] = [];
+
+  function visit(node: ts.Node) {
+    // Look for .register() call expressions
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "register"
+    ) {
+      const meta = extractFromRegisterCall(node, sourceFile, checker);
+      if (meta) {
+        results.push(meta);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return results;
+}
+
+function extractFromRegisterCall(
+  registerCall: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker
+): StepDefinitionMeta | null {
+  // Walk backwards through the method chain to find all parts
+  // Pattern: builder().statement(...).dependencies?(...).step(...).register()
+  // Or: Variable("...").dependencies?(...).step(...).register()
+
+  const chain = collectCallChain(registerCall);
+
+  let stepType: StepType | null = null;
+  let expression: string | null = null;
+  let dependencies: StepDefinitionMeta["dependencies"] = {
+    given: {},
+    when: {},
+    then: {},
+  };
+  let produces: string[] = [];
+
+  for (const link of chain) {
+    const name = getCallName(link);
+    if (!name) continue;
+
+    if (name === "register") {
+      // Already at register, continue
+      continue;
+    }
+
+    if (name === "step") {
+      produces = extractProducedKeys(link, checker);
+      continue;
+    }
+
+    if (name === "dependencies") {
+      dependencies = extractDependencies(link);
+      continue;
+    }
+
+    if (name === "statement") {
+      expression = extractExpression(link);
+      // Try to find the builder type by continuing up the chain
+      continue;
+    }
+
+    // Check if this is a builder call like givenBuilder()
+    if (BUILDER_NAMES[name]) {
+      stepType = BUILDER_NAMES[name];
+      continue;
+    }
+  }
+
+  // If we didn't find the builder or expression in the chain, try the "re-exported" pattern:
+  // const Given = givenBuilder<T>().statement;
+  // Given("foo").step(...).register()
+  if (!stepType || !expression) {
+    const reExport = resolveReExportedCall(chain, checker);
+    if (reExport) {
+      if (!stepType) stepType = reExport.stepType;
+      if (!expression) expression = reExport.expression;
+    }
+  }
+
+  if (!stepType || !expression) {
+    return null;
+  }
+
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(registerCall.getStart()).line + 1;
+
+  return {
+    stepType,
+    expression,
+    dependencies,
+    produces,
+    sourceFile: sourceFile.fileName,
+    line,
+  };
+}
+
+/**
+ * Collect all call expressions in the method chain, from register() back to the origin.
+ */
+function collectCallChain(call: ts.CallExpression): ts.CallExpression[] {
+  const chain: ts.CallExpression[] = [call];
+  let current: ts.Expression = call.expression;
+
+  while (true) {
+    // Walk through PropertyAccessExpression to find the next call
+    if (ts.isPropertyAccessExpression(current)) {
+      current = current.expression;
+    }
+
+    if (ts.isCallExpression(current)) {
+      chain.push(current);
+      current = current.expression;
+    } else {
+      break;
+    }
+  }
+
+  return chain;
+}
+
+function getCallName(call: ts.CallExpression): string | null {
+  const expr = call.expression;
+
+  // .method() pattern
+  if (ts.isPropertyAccessExpression(expr)) {
+    return expr.name.text;
+  }
+
+  // direct call: functionName()
+  if (ts.isIdentifier(expr)) {
+    return expr.text;
+  }
+
+  return null;
+}
+
+function extractExpression(statementCall: ts.CallExpression): string | null {
+  const arg = statementCall.arguments[0];
+  if (!arg) return null;
+
+  // String literal: .statement("a user")
+  if (ts.isStringLiteral(arg)) {
+    return arg.text;
+  }
+
+  // Arrow function with template literal: .statement((name: string) => `a user named ${name}`)
+  if (ts.isArrowFunction(arg)) {
+    return extractExpressionFromArrowFunction(arg);
+  }
+
+  return null;
+}
+
+function extractExpressionFromArrowFunction(
+  fn: ts.ArrowFunction
+): string | null {
+  const params = fn.parameters.map((p) => p.name.getText());
+
+  // The body should be a template expression or string literal
+  let body = fn.body;
+
+  // If wrapped in a block with a return, unwrap
+  if (ts.isBlock(body)) {
+    const returnStmt = body.statements.find(ts.isReturnStatement);
+    if (returnStmt?.expression) {
+      body = returnStmt.expression;
+    } else {
+      return null;
+    }
+  }
+
+  if (ts.isTemplateExpression(body)) {
+    return reconstructExpressionFromTemplate(body, params);
+  }
+
+  if (ts.isNoSubstitutionTemplateLiteral(body)) {
+    return body.text;
+  }
+
+  return null;
+}
+
+function reconstructExpressionFromTemplate(
+  template: ts.TemplateExpression,
+  paramNames: string[]
+): string {
+  let result = template.head.text;
+
+  for (const span of template.templateSpans) {
+    if (ts.isIdentifier(span.expression) && paramNames.includes(span.expression.text)) {
+      result += "{string}";
+    } else {
+      // Non-parameter expression, use {string} as fallback
+      result += "{string}";
+    }
+    result += span.literal.text;
+  }
+
+  return result;
+}
+
+function extractDependencies(
+  depsCall: ts.CallExpression
+): StepDefinitionMeta["dependencies"] {
+  const deps: StepDefinitionMeta["dependencies"] = {
+    given: {},
+    when: {},
+    then: {},
+  };
+
+  const arg = depsCall.arguments[0];
+  if (!arg || !ts.isObjectLiteralExpression(arg)) return deps;
+
+  for (const prop of arg.properties) {
+    if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name))
+      continue;
+
+    const phase = prop.name.text as "given" | "when" | "then";
+    if (!deps[phase]) continue;
+
+    if (ts.isObjectLiteralExpression(prop.initializer)) {
+      for (const innerProp of prop.initializer.properties) {
+        if (
+          ts.isPropertyAssignment(innerProp) &&
+          ts.isIdentifier(innerProp.name) &&
+          ts.isStringLiteral(innerProp.initializer)
+        ) {
+          const val = innerProp.initializer.text;
+          if (val === "required" || val === "optional") {
+            deps[phase][innerProp.name.text] = val;
+          }
+        }
+      }
+    }
+  }
+
+  return deps;
+}
+
+function extractProducedKeys(
+  stepCall: ts.CallExpression,
+  checker: ts.TypeChecker
+): string[] {
+  const callback = stepCall.arguments[0];
+  if (!callback) return [];
+
+  // Try to get the return type of the callback by analyzing its body
+  if (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback)) {
+    return extractProducedKeysFromCallback(callback, checker);
+  }
+
+  return [];
+}
+
+function extractProducedKeysFromCallback(
+  callback: ts.ArrowFunction | ts.FunctionExpression,
+  checker: ts.TypeChecker
+): string[] {
+  const body = callback.body;
+
+  // Concise arrow: () => ({ key: value })
+  if (!ts.isBlock(body)) {
+    return extractKeysFromExpression(body, checker);
+  }
+
+  // Block body: look at return statements
+  const keys = new Set<string>();
+  function visitReturn(node: ts.Node) {
+    if (ts.isReturnStatement(node) && node.expression) {
+      for (const key of extractKeysFromExpression(node.expression, checker)) {
+        keys.add(key);
+      }
+    }
+    ts.forEachChild(node, visitReturn);
+  }
+  visitReturn(body);
+  return [...keys];
+}
+
+function extractKeysFromExpression(
+  expr: ts.Expression,
+  checker: ts.TypeChecker
+): string[] {
+  // Unwrap parenthesized expressions
+  while (ts.isParenthesizedExpression(expr)) {
+    expr = expr.expression;
+  }
+
+  // Object literal: { user: ..., token: ... }
+  if (ts.isObjectLiteralExpression(expr)) {
+    return expr.properties
+      .filter(
+        (p): p is ts.PropertyAssignment | ts.ShorthandPropertyAssignment =>
+          ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)
+      )
+      .map((p) => p.name.getText())
+      .filter(Boolean);
+  }
+
+  // Try type checker as fallback
+  try {
+    const type = checker.getTypeAtLocation(expr);
+    return type
+      .getProperties()
+      .map((p) => p.name)
+      .filter((n) => n !== "merge");
+  } catch {
+    return [];
+  }
+}
+
+interface ReExportResult {
+  stepType: StepType;
+  expression: string | null;
+}
+
+function resolveReExportedCall(
+  chain: ts.CallExpression[],
+  checker: ts.TypeChecker
+): ReExportResult | null {
+  // Look for the pattern: Variable("...")... where Variable was assigned from builderType().statement
+  // The last call in the chain (furthest from register) should be the variable call
+
+  const lastCall = chain[chain.length - 1];
+  if (!lastCall) return null;
+
+  const expr = lastCall.expression;
+
+  // If it's an identifier (like "Given", "When", "Then"), trace its declaration
+  let identifier: ts.Identifier | null = null;
+  if (ts.isIdentifier(expr)) {
+    identifier = expr;
+  } else if (
+    ts.isPropertyAccessExpression(expr) &&
+    ts.isIdentifier(expr.expression)
+  ) {
+    identifier = expr.expression;
+  }
+
+  if (!identifier) return null;
+
+  const symbol = checker.getSymbolAtLocation(identifier);
+  if (!symbol) return null;
+
+  const decl = symbol.valueDeclaration;
+  if (!decl || !ts.isVariableDeclaration(decl) || !decl.initializer)
+    return null;
+
+  // Check if initializer is builderType<T>().statement
+  const init = decl.initializer;
+
+  // Pattern: givenBuilder<T>().statement  (PropertyAccessExpression)
+  if (ts.isPropertyAccessExpression(init) && init.name.text === "statement") {
+    const callExpr = init.expression;
+    if (ts.isCallExpression(callExpr)) {
+      const callee = callExpr.expression;
+      if (ts.isIdentifier(callee) && BUILDER_NAMES[callee.text]) {
+        // The lastCall IS the statement call — extract expression from it
+        const expression = extractExpression(lastCall);
+        return {
+          stepType: BUILDER_NAMES[callee.text],
+          expression,
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/analyzer/stepMatcher.ts
+++ b/src/analyzer/stepMatcher.ts
@@ -1,0 +1,63 @@
+import {
+  CucumberExpression,
+  ParameterTypeRegistry,
+} from "@cucumber/cucumber-expressions";
+import { MatchedStep, ParsedScenario, StepDefinitionMeta } from "./types.js";
+
+interface CompiledExpression {
+  expression: CucumberExpression;
+  definition: StepDefinitionMeta;
+}
+
+export function matchScenarioSteps(
+  scenario: ParsedScenario,
+  definitions: StepDefinitionMeta[]
+): MatchedStep[] {
+  const registry = new ParameterTypeRegistry();
+
+  const compiled: CompiledExpression[] = [];
+  for (const def of definitions) {
+    try {
+      const expression = new CucumberExpression(def.expression, registry);
+      compiled.push({ expression, definition: def });
+    } catch {
+      // Skip definitions with invalid expressions
+    }
+  }
+
+  return scenario.steps.map((step) => {
+    const match = findMatch(step.text, step.effectiveKeyword, compiled);
+    return {
+      ...step,
+      definition: match,
+    };
+  });
+}
+
+function findMatch(
+  text: string,
+  effectiveKeyword: "Given" | "When" | "Then",
+  compiled: CompiledExpression[]
+): StepDefinitionMeta | null {
+  const keywordToStepType: Record<string, string> = {
+    Given: "given",
+    When: "when",
+    Then: "then",
+  };
+  const expectedStepType = keywordToStepType[effectiveKeyword];
+
+  // First try to match with the correct step type
+  for (const { expression, definition } of compiled) {
+    if (definition.stepType !== expectedStepType) continue;
+    const result = expression.match(text);
+    if (result) return definition;
+  }
+
+  // Fallback: match any step type (Cucumber itself doesn't enforce keyword-to-step-type)
+  for (const { expression, definition } of compiled) {
+    const result = expression.match(text);
+    if (result) return definition;
+  }
+
+  return null;
+}

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -1,0 +1,55 @@
+export interface StepDefinitionMeta {
+  stepType: "given" | "when" | "then";
+  expression: string;
+  dependencies: {
+    given: Record<string, "required" | "optional">;
+    when: Record<string, "required" | "optional">;
+    then: Record<string, "required" | "optional">;
+  };
+  produces: string[];
+  sourceFile: string;
+  line: number;
+}
+
+export interface ParsedScenario {
+  name: string;
+  file: string;
+  steps: ParsedStep[];
+}
+
+export interface ParsedStep {
+  keyword: "Given" | "When" | "Then" | "And" | "But";
+  effectiveKeyword: "Given" | "When" | "Then";
+  text: string;
+  line: number;
+  column: number;
+}
+
+export interface MatchedStep extends ParsedStep {
+  definition: StepDefinitionMeta | null;
+}
+
+export interface Diagnostic {
+  file: string;
+  range: {
+    startLine: number;
+    startColumn: number;
+    endLine: number;
+    endColumn: number;
+  };
+  severity: "error" | "warning" | "info";
+  message: string;
+  rule: string;
+  source: "step-forge";
+}
+
+export interface AnalysisRule {
+  name: string;
+  check(scenario: ParsedScenario, matchedSteps: MatchedStep[]): Diagnostic[];
+}
+
+export interface AnalyzerConfig {
+  stepFiles: string[];
+  featureFiles: string[];
+  tsConfigPath?: string;
+}


### PR DESCRIPTION
Add a stand alone utility for analyzing feature files against the steps that are configured.

## Summary

  - Add a Cucumber-based test harness for the analyzer, using fixture step definitions and feature files that the analyzer reads as data (never
  executed by Cucumber)
  - Include 8 test scenarios covering passing cases (no deps, satisfied deps, variables, optional deps, And/But keywords) and failing cases
  (missing given dep, missing when dep, multiple missing deps)
  - Update cucumber.mjs to use non-recursive path globs so fixture .feature files are excluded from Cucumber's test discovery
  - Document all test scripts, the analyzer test architecture, and how to add new analyzer tests in both CLAUDE.md and features/TESTING.md

## Test architecture

  features/analyzer/
    analyzer.feature              ← 8 scenarios run by Cucumber
    fixtures/
      steps.ts                    ← Step defs read by extractor as AST data
      valid-no-deps.feature       ← Feature files read by parser as Gherkin data
      valid-deps.feature
      missing-given-dep.feature
      ...

  The step definitions in features/steps/analyzerSteps.ts call the analyze() API against the fixture files and assert on the returned diagnostics.
   This validates the full pipeline (extraction → parsing → matching → rule checking) end-to-end without needing to run the fixtures as Cucumber
  tests.

## Test plan

  - npm test — all 13 scenarios pass (5 existing + 8 new)
  - npm run build — still succeeds
  - Review fixture coverage against analyzer rules