### PR TITLE
Missing steps

### DIFF
--- a/features/analyzer/analyzer.feature
+++ b/features/analyzer/analyzer.feature
@@ -30,21 +30,45 @@ Feature: Analyzer dependency verification
     When I analyze the files
     Then there should be no errors
 
+  # --- Undefined step scenarios ---
+
+  Scenario: Undefined step reports an error
+    Given a feature file "undefined-step.feature"
+    When I analyze the files
+    Then there should be 1 error
+    And there is 1 error for rule "undefined-step"
+    And an error should mention "I do something that does not exist"
+    And an error should mention "does not match any step definition"
+
+  Scenario: Undefined step combined with missing dependency
+    Given a feature file "undefined-with-missing-dep.feature"
+    When I analyze the files
+    Then there should be 2 errors
+    And there is 1 error for rule "undefined-step"
+    And an error should mention "I do something that does not exist"
+    And there is 1 error for rule "dependency-check"
+    And an error should mention "given.user"
+
   # --- Failing scenarios ---
 
   Scenario: Missing required given dependency reports an error
     Given a feature file "missing-given-dep.feature"
     When I analyze the files
-    Then there should be 1 errors
+    Then there should be 1 error
+    And there is 1 error for rule "dependency-check"
     And an error should mention "given.user"
 
   Scenario: Missing required when dependency reports an error
     Given a feature file "missing-when-dep.feature"
     When I analyze the files
-    Then there should be 1 errors
+    Then there should be 1 error
+    And there is 1 error for rule "dependency-check"
     And an error should mention "when.user"
 
   Scenario: Multiple missing dependencies reports multiple errors
     Given a feature file "missing-multiple-deps.feature"
     When I analyze the files
     Then there should be 2 errors
+    And there are 2 errors for rule "dependency-check"
+    And an error should mention "given.user"
+    And an error should mention "given.account"

--- a/features/analyzer/analyzer.feature
+++ b/features/analyzer/analyzer.feature
@@ -49,6 +49,15 @@ Feature: Analyzer dependency verification
     And there is 1 error for rule "dependency-check"
     And an error should mention "given.user"
 
+  # --- Ambiguous step scenarios ---
+
+  Scenario: Ambiguous step reports an error
+    Given a feature file "ambiguous-step.feature"
+    When I analyze the files
+    Then there should be 1 error
+    And there is 1 error for rule "ambiguous-step"
+    And an error should mention "matches multiple step definitions"
+
   # --- Failing scenarios ---
 
   Scenario: Missing required given dependency reports an error

--- a/features/analyzer/fixtures/ambiguous-step.feature
+++ b/features/analyzer/fixtures/ambiguous-step.feature
@@ -1,0 +1,5 @@
+Feature: Ambiguous step
+  Scenario: Uses an ambiguous step
+    Given the system is ready
+    When I got here
+    Then everything was good

--- a/features/analyzer/fixtures/steps.ts
+++ b/features/analyzer/fixtures/steps.ts
@@ -58,6 +58,18 @@ givenBuilder<GivenState>()
   })
   .register();
 
+// --- Ambiguous steps (same expression, two definitions) --- //
+
+givenBuilder<GivenState>()
+  .statement("the system is ready")
+  .step(() => ({}))
+  .register();
+
+givenBuilder<GivenState>()
+  .statement("the system is ready")
+  .step(() => ({}))
+  .register();
+
 // --- When steps with dependencies --- //
 
 whenBuilder<GivenState, WhenState>()

--- a/features/analyzer/fixtures/undefined-step.feature
+++ b/features/analyzer/fixtures/undefined-step.feature
@@ -1,0 +1,5 @@
+Feature: Undefined step
+  Scenario: Uses an undefined step
+    Given a user
+    When I do something that does not exist
+    Then everything was good

--- a/features/analyzer/fixtures/undefined-with-missing-dep.feature
+++ b/features/analyzer/fixtures/undefined-with-missing-dep.feature
@@ -1,0 +1,5 @@
+Feature: Undefined step with missing dependency
+  Scenario: Has both undefined and missing dependency
+    When I save the user
+    When I do something that does not exist
+    Then everything was good

--- a/features/steps/analyzerSteps.ts
+++ b/features/steps/analyzerSteps.ts
@@ -41,3 +41,13 @@ Then("an error should mention {string}", function (substring: string) {
   const found = errors.some((e) => e.message.includes(substring));
   expect(found).toEqual(true);
 });
+
+Then(
+  "there is/are {int} error/errors for rule {string}",
+  function (count: number, rule: string) {
+    const errors = diagnostics.filter(
+      (d) => d.severity === "error" && d.rule === rule
+    );
+    expect(errors).toHaveLength(count);
+  }
+);

--- a/src/analyzer/rules/ambiguousStepRule.ts
+++ b/src/analyzer/rules/ambiguousStepRule.ts
@@ -1,0 +1,36 @@
+import {
+  AnalysisRule,
+  Diagnostic,
+  MatchedStep,
+  ParsedScenario,
+} from "../types.js";
+
+export const ambiguousStepRule: AnalysisRule = {
+  name: "ambiguous-step",
+
+  check(
+    scenario: ParsedScenario,
+    matchedSteps: MatchedStep[]
+  ): Diagnostic[] {
+    return matchedSteps
+      .filter((step) => step.definitions.length > 1)
+      .map((step) => {
+        const locations = step.definitions
+          .map((d) => `${d.sourceFile}:${d.line}`)
+          .join(", ");
+        return {
+          file: scenario.file,
+          range: {
+            startLine: step.line,
+            startColumn: step.column,
+            endLine: step.line,
+            endColumn: step.column + step.text.length,
+          },
+          severity: "error" as const,
+          message: `Step "${step.text}" matches multiple step definitions: ${locations}`,
+          rule: "ambiguous-step",
+          source: "step-forge" as const,
+        };
+      });
+  },
+};

--- a/src/analyzer/rules/dependencyRule.ts
+++ b/src/analyzer/rules/dependencyRule.ts
@@ -20,9 +20,9 @@ export const dependencyRule: AnalysisRule = {
     };
 
     for (const step of matchedSteps) {
-      if (!step.definition) continue;
+      if (step.definitions.length !== 1) continue;
 
-      const { dependencies, produces, stepType } = step.definition;
+      const { dependencies, produces, stepType } = step.definitions[0];
 
       // Check required dependencies
       for (const phase of ["given", "when", "then"] as const) {
@@ -40,7 +40,7 @@ export const dependencyRule: AnalysisRule = {
                 endColumn: step.column + step.text.length,
               },
               severity: "error",
-              message: `Step "${step.text}" requires '${phase}.${key}' but no preceding step produces it. Available ${phase} keys: ${availableStr}. Defined in: ${step.definition.sourceFile}:${step.definition.line}`,
+              message: `Step "${step.text}" requires '${phase}.${key}' but no preceding step produces it. Available ${phase} keys: ${availableStr}. Defined in: ${step.definitions[0].sourceFile}:${step.definitions[0].line}`,
               rule: "dependency-check",
               source: "step-forge",
             });

--- a/src/analyzer/rules/index.ts
+++ b/src/analyzer/rules/index.ts
@@ -4,10 +4,15 @@ import {
   MatchedStep,
   ParsedScenario,
 } from "../types.js";
+import { ambiguousStepRule } from "./ambiguousStepRule.js";
 import { dependencyRule } from "./dependencyRule.js";
 import { undefinedStepRule } from "./undefinedStepRule.js";
 
-export const defaultRules: AnalysisRule[] = [undefinedStepRule, dependencyRule];
+export const defaultRules: AnalysisRule[] = [
+  undefinedStepRule,
+  ambiguousStepRule,
+  dependencyRule,
+];
 
 export function runRules(
   rules: AnalysisRule[],

--- a/src/analyzer/rules/index.ts
+++ b/src/analyzer/rules/index.ts
@@ -5,8 +5,9 @@ import {
   ParsedScenario,
 } from "../types.js";
 import { dependencyRule } from "./dependencyRule.js";
+import { undefinedStepRule } from "./undefinedStepRule.js";
 
-export const defaultRules: AnalysisRule[] = [dependencyRule];
+export const defaultRules: AnalysisRule[] = [undefinedStepRule, dependencyRule];
 
 export function runRules(
   rules: AnalysisRule[],

--- a/src/analyzer/rules/undefinedStepRule.ts
+++ b/src/analyzer/rules/undefinedStepRule.ts
@@ -1,0 +1,31 @@
+import {
+  AnalysisRule,
+  Diagnostic,
+  MatchedStep,
+  ParsedScenario,
+} from "../types.js";
+
+export const undefinedStepRule: AnalysisRule = {
+  name: "undefined-step",
+
+  check(
+    scenario: ParsedScenario,
+    matchedSteps: MatchedStep[]
+  ): Diagnostic[] {
+    return matchedSteps
+      .filter((step) => step.definition === null)
+      .map((step) => ({
+        file: scenario.file,
+        range: {
+          startLine: step.line,
+          startColumn: step.column,
+          endLine: step.line,
+          endColumn: step.column + step.text.length,
+        },
+        severity: "error" as const,
+        message: `Step "${step.text}" does not match any step definition`,
+        rule: "undefined-step",
+        source: "step-forge" as const,
+      }));
+  },
+};

--- a/src/analyzer/rules/undefinedStepRule.ts
+++ b/src/analyzer/rules/undefinedStepRule.ts
@@ -13,7 +13,7 @@ export const undefinedStepRule: AnalysisRule = {
     matchedSteps: MatchedStep[]
   ): Diagnostic[] {
     return matchedSteps
-      .filter((step) => step.definition === null)
+      .filter((step) => step.definitions.length === 0)
       .map((step) => ({
         file: scenario.file,
         range: {

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -26,7 +26,7 @@ export interface ParsedStep {
 }
 
 export interface MatchedStep extends ParsedStep {
-  definition: StepDefinitionMeta | null;
+  definitions: StepDefinitionMeta[];
 }
 
 export interface Diagnostic {


### PR DESCRIPTION
 Summary

  - Add undefined-step analyzer rule that detects feature file steps with no matching step definition
  - Add ambiguous-step analyzer rule that detects feature file steps matching multiple step definitions (which would cause a Cucumber.js runtime
  error)
  - Refactor MatchedStep from single definition: StepDefinitionMeta | null to definitions: StepDefinitionMeta[] so the matcher collects all
  matches and rules can distinguish between zero, one, and multiple matches
  - Improve existing test scenarios with rule-specific error count assertions

  Changes

  Core: MatchedStep type change (src/analyzer/types.ts)

  definition: StepDefinitionMeta | null → definitions: StepDefinitionMeta[], where [] = undefined, [def] = single match, [def1, def2, ...] =
  ambiguous.

  Matcher: collect all matches (src/analyzer/stepMatcher.ts)

  findMatch → findMatches now returns all matching definitions instead of short-circuiting on the first one. Type-prioritized matches still take
  precedence over fallback matches.

  New rules

  - undefinedStepRule — reports an error when definitions.length === 0
  - ambiguousStepRule — reports an error when definitions.length > 1, listing the conflicting definition locations in the message

  Updated rules

  - dependencyRule — adapted to use definitions[0]; skips steps that are undefined or ambiguous (definitions.length !== 1)

  Rule ordering

  defaultRules is now: undefinedStepRule → ambiguousStepRule → dependencyRule

  Test plan

  - npm run test:debug — all 16 scenarios pass (including new undefined-step and ambiguous-step scenarios)
  - npm run build — compiles cleanly
  - New test fixtures: ambiguous-step.feature, undefined-step.feature, undefined-with-missing-dep.feature with corresponding duplicate step
  definitions in steps.ts
  - Existing analyzer tests continue to pass with the definitions array refactor