### PR TITLE
[WIP] Better variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,19 @@ Step Forge is a TypeScript library for writing **type-safe Gherkin step definiti
 
 ### Builder Chain
 
-Each Gherkin phase (given/when/then) has a builder that follows this chain:
+Each Gherkin phase (given/when/then) has a builder with two entry styles:
 
 ```
-builder<State>().statement(str | fn) → .parsers?(parsers) → .dependencies?(deps) → .step(fn)
+builder<State>().statement("plain string")                     → .dependencies?(deps) → .step(fn)
+builder<State>().variables({name: parser}).statement(v => ...) → .dependencies?(deps) → .step(fn)
 ```
 
-- **Statement**: A string or function. Functions define variables via parameters: `(name: string) => \`a user named ${name}\`` — each parameter becomes a placeholder in the step expression (`{string}` by default, or the placeholder of the matching parser).
-- **Parsers**: Optional, one per variable. A `Parser<T>` is a cucumber-expression _parameter type_: `{ name, regexp, parse }`. `name` drives the placeholder (`{name}`), `regexp` is how the value is recognised in step text, and `parse` transforms the match into `T`. The engine registers each parser into the expression's `ParameterTypeRegistry`, so matching and coercion happen in one pass (`parse` runs during matching, not after). This lets a parser introduce a novel placeholder like `{color}` that genuinely constrains matching. Built-in-named parsers (`{int}`/`{float}`/`{string}`) defer to cucumber's own built-in types. Default is `stringParser` for every variable.
+- **Variables**: A statement with variables must declare them first via `.variables({ amount: intParser, currency: stringParser })` — a name → parser map that is the single source of truth for each variable's name, placeholder, and TypeScript type. There is no positional style and no `.parsers()`; every variable's parser is explicit (use `stringParser` for strings).
+- **Statement**: A plain string (no variables), or — after `.variables()` — a function receiving one opaque token per declared variable: `` v => `a user named ${v.userName}` ``. At registration the statement is called once with recording tokens (`renderNamedExpression` in `src/variables.ts`): each token's `toString()` renders its parser's placeholder and records interpolation order, which is how positional captures map back to names at run time. Every declared variable must be interpolated exactly once or registration throws. Tokens are branded (`Variable<T, Name>`) so hovering `v.amount` shows `Variable<number, "int">` and any non-interpolation use is a type error.
+- **Parsers**: A `Parser<T, Name>` is a cucumber-expression _parameter type_: `{ name, regexp, parse }`. `name` drives the placeholder (`{name}`), `regexp` is how the value is recognised in step text, and `parse` transforms the match into `T`. The engine registers each parser into the expression's `ParameterTypeRegistry`, so matching and coercion happen in one pass (`parse` runs during matching, not after). This lets a parser introduce a novel placeholder like `{color}` that genuinely constrains matching. Built-in-named parsers (`{int}`/`{float}`/`{string}`) defer to cucumber's own built-in types. Declare custom parsers with a literal name type (`Parser<Color, "color">`) so hovers and the analyzer see the placeholder.
 - **Dependencies**: Declare which keys from other phases' state this step needs. Keys are marked `"required"` or `"optional"`. Required deps are validated at runtime; optional ones may be `undefined`.
-- **Step function**: Receives `{ variables, given, when, then }` — only the phases allowed by the builder type are accessible (given steps can't access when/then state).
-- **`.step(fn)` registers.** Calling `.step()` is the terminal action: it adds the step to the runtime registry (`globalRegistry`) and returns the step metadata (`{ statement, expression, dependencies, stepType, stepFunction }`). There is no `.register()` — calling `.step()` on a partial chain both builds and registers, so building a step purely to inspect its `.expression` also registers it.
+- **Step function**: Receives `{ variables, given, when, then }` — `variables` is a name-keyed object typed from the parsers; only the phases allowed by the builder type are accessible (given steps can't access when/then state).
+- **`.step(fn)` registers.** Calling `.step()` is the terminal action: it adds the step to the runtime registry (`globalRegistry`) and returns the step metadata (`{ statement, expression, dependencies, stepType, stepFunction }`). `expression` is literal-typed: the exact string for a string statement, a `${string}`-holed template type for a token statement. There is no `.register()` — calling `.step()` on a partial chain both builds and registers, so building a step purely to inspect its `.expression` also registers it.
 
 ### Phase Restrictions
 
@@ -45,9 +47,10 @@ builder<State>().statement(str | fn) → .parsers?(parsers) → .dependencies?(d
 
 ### Key Source Files
 
-- `src/common.ts` — `addStep()`: builds the step `expression` from the statement + parsers, wires the `execute(world, rawArgs)` body (parser coercion, dependency validation/narrowing, state merge), and registers into `globalRegistry` on `.step()`.
+- `src/common.ts` — `addStep()`: renders the step `expression` from the statement + variables map (via `renderNamedExpression`), wires the `execute(world, rawArgs)` body (dependency validation/narrowing, positional-capture → named-variables mapping, state merge), and registers into `globalRegistry` on `.step()`.
+- `src/variables.ts` — the named-variable machinery: `VariableMap`, `Variable<T, Name>` (branded token type), `VariableTokens`, `VariablesOf`, and `renderNamedExpression()` (token `toString()` dance that renders placeholders and records interpolation order; validates each variable is interpolated exactly once).
 - `src/given.ts`, `src/when.ts`, `src/then.ts` — Builder implementations with phase-specific type constraints
-- `src/parsers.ts` — `Parser<T>` (`{ name, regexp, parse }`, a cucumber-expression parameter type) plus builtins: `stringParser` (`{string}`, strips quotes), `intParser` (`{int}`), `numberParser` (`{float}`), `booleanParser` (custom `{boolean}`, matches `true`/`false`)
+- `src/parsers.ts` — `Parser<T, Name extends string = string>` (`{ name, regexp, parse }`, a cucumber-expression parameter type; `Name` is a literal type on the builtins) plus builtins: `stringParser` (`{string}`, strips quotes), `intParser` (`{int}`), `numberParser` (`{float}`), `booleanParser` (custom `{boolean}`, matches `true`/`false`)
 - `src/world.ts` — `BasicWorld<Given, When, Then>` with `MergeableWorldState` (lodash deep merge, arrays concatenate)
 - `src/builderTypeUtils.ts` — TypeScript utility types driving the builder's type safety
 - `src/utils.ts` — `requireFrom{Given,When,Then}()` for runtime required-dependency validation
@@ -82,6 +85,10 @@ In-repo the runner and the step files both import from `src/` directly (Bun runs
 
 The analyzer (`src/analyzer/`) statically checks `.feature` files against step definitions without running them. It parses features with `@cucumber/gherkin` (`gherkinParser.ts`), extracts step metadata from TypeScript source via the AST (`stepExtractor.ts`, keyed off the terminal `.step(...)` call), matches them (`stepMatcher.ts`), and runs rules (`rules/`). Exposed as the `analyze()` API (`@step-forge/step-forge/analyzer`) and the `step-forge-analyze` CLI.
 
+Expression extraction reconstructs each hole's **exact** placeholder from the `.variables()` map: built-in parsers resolve by export name on the parse-only fast path, same-file custom parsers by reading their declaration's `name` property (and `regexp`, emitted as `StepDefinitionMeta.parameters`), and imported custom parsers via the type checker (the `name` property of a `Parser<T, "name">` is a string-literal type — this triggers the one-time type-checked retry; `regexp` is a runtime value, so imported parsers get no pattern). An unresolvable hole falls back to `{string}`.
+
+Matching (`stepMatcher.ts`) is **strict and case-sensitive** like the engine: placeholders match by their real syntax — `{int}`/`{float}` numeric, `{string}` quoted, `{boolean}` true/false, custom placeholders by their extracted `parameters` pattern — with `.+` only for a placeholder the extractor couldn't resolve. `I deposit ten` against `I deposit {int}` is an undefined-step diagnostic, not a match. Tests: `src/analyzer/stepExtractor.test.ts` + `stepMatcher.test.ts` (units, against `features/analyzer/fixtures/steps.ts`), and the `valid-parsers.feature` / `mismatched-parsers.feature` scenarios in `analyzer.feature` (end-to-end).
+
 ### Build Output
 
 `tsdown` (configured in `tsdown.config.ts`, powered by rolldown) produces JS bundles and bundled type declarations in one pass. Two build groups:
@@ -93,7 +100,7 @@ Dependencies and `node:` builtins are externalized automatically. The `build/` d
 
 ## Exports
 
-- `@step-forge/step-forge` — `givenBuilder`, `whenBuilder`, `thenBuilder`, `BasicWorld`, the parsers (`stringParser`, `intParser`, `numberParser`, `booleanParser`), `createBuilders`, the hooks (`beforeScenario`/`afterScenario`/`beforeFeature`/`afterFeature`/`beforeAll`/`afterAll`), and types (`Parser`, `StateFromDependencies`, `RunnerOptions` for typing `step-forge.config.ts`, …). From `src/index.ts`.
+- `@step-forge/step-forge` — `givenBuilder`, `whenBuilder`, `thenBuilder`, `BasicWorld`, the parsers (`stringParser`, `intParser`, `numberParser`, `booleanParser`), `createBuilders` (pre-bound builders: `Given("...")` for strings, `Given.variables({...}).statement(v => ...)` for variables), the hooks (`beforeScenario`/`afterScenario`/`beforeFeature`/`afterFeature`/`beforeAll`/`afterAll`), and types (`Parser`, `Variable`, `VariableMap`, `VariableTokens`, `VariablesOf`, `NoVariables`, `StateFromDependencies`, `RunnerOptions` for typing `step-forge.config.ts`, …). From `src/index.ts`.
 - `@step-forge/step-forge/runtime` — `runScenario`, `compileRegistry`, `StepRegistry`, `globalRegistry`, `UndefinedStepError`, `AmbiguousStepError`, the `RunnerOptions` type, and their types.
 - `@step-forge/step-forge/analyzer` — `analyze()` and related APIs.
 - Bins: `step-forge` (the feature runner, `src/runtime/cli.ts`) and `step-forge-analyze` (the analyzer CLI). Both run under **Bun**.

--- a/features/analyzer/analyzer.feature
+++ b/features/analyzer/analyzer.feature
@@ -30,6 +30,11 @@ Feature: Analyzer dependency verification
     When I analyze the files
     Then there should be no errors
 
+  Scenario: Named variables with int and custom parsers produce no errors
+    Given a feature file "valid-parsers.feature"
+    When I analyze the files
+    Then there should be no errors
+
   # --- Undefined step scenarios ---
 
   Scenario: Undefined step reports an error
@@ -48,6 +53,14 @@ Feature: Analyzer dependency verification
     And an error should mention "I do something that does not exist"
     And there is 1 error for rule "dependency-check"
     And an error should mention "given.user"
+
+  Scenario: Step text that cannot satisfy the declared placeholders reports undefined steps
+    Given a feature file "mismatched-parsers.feature"
+    When I analyze the files
+    Then there should be 2 errors
+    And there are 2 errors for rule "undefined-step"
+    And an error should mention "my favorite color is purple"
+    And an error should mention "I deposit ten"
 
   # --- Ambiguous step scenarios ---
 

--- a/features/analyzer/fixtures/mismatched-parsers.feature
+++ b/features/analyzer/fixtures/mismatched-parsers.feature
@@ -1,0 +1,7 @@
+Feature: Placeholder value mismatches
+
+  Scenario: Values that do not fit the declared parsers
+    Given a user
+    And my favorite color is purple
+    When I deposit ten "USD"
+    Then everything was good

--- a/features/analyzer/fixtures/steps.ts
+++ b/features/analyzer/fixtures/steps.ts
@@ -1,10 +1,22 @@
 import { givenBuilder } from "../../../src/given";
 import { whenBuilder } from "../../../src/when";
 import { thenBuilder } from "../../../src/then";
+import { intParser, stringParser, Parser } from "../../../src/parsers";
+
+type Color = "red" | "green" | "blue";
+
+// A custom parser declared in this file: the extractor resolves its `{color}`
+// placeholder from this declaration's `name` property.
+const colorParser: Parser<Color, "color"> = {
+  name: "color",
+  regexp: /red|green|blue/,
+  parse: raw => raw as Color,
+};
 
 type GivenState = {
   user: { type: string; token: string };
   account: { id: string };
+  favoriteColor: Color;
 };
 type WhenState = {
   user: { type: string; token: string; saved: boolean };
@@ -37,10 +49,32 @@ givenBuilder<GivenState>()
   });
 
 givenBuilder<GivenState>()
-  .statement((name: string) => `a user named ${name}`)
-  .step(({ variables: [name] }) => {
+  .variables({ name: stringParser })
+  .statement(v => `a user named ${v.name}`)
+  .step(({ variables: { name } }) => {
     return {
       user: { type: "person", token: name },
+    };
+  });
+
+// --- Steps with non-string placeholders (extractor must resolve these) --- //
+
+givenBuilder<GivenState>()
+  .variables({ color: colorParser })
+  .statement(v => `my favorite color is ${v.color}`)
+  .step(({ variables: { color } }) => {
+    return {
+      favoriteColor: color,
+    };
+  });
+
+whenBuilder<GivenState, WhenState>()
+  .variables({ amount: intParser, currency: stringParser })
+  .statement(v => `I deposit ${v.amount} ${v.currency}`)
+  .dependencies({ given: { user: "required" } })
+  .step(() => {
+    return {
+      result: { success: true },
     };
   });
 
@@ -90,7 +124,8 @@ thenBuilder<GivenState, WhenState, ThenState>()
   .step(() => {});
 
 thenBuilder<GivenState, WhenState, ThenState>()
-  .statement((name: string) => `the user's name is ${name}`)
+  .variables({ name: stringParser })
+  .statement(v => `the user's name is ${v.name}`)
   .dependencies({ when: { user: "required" } })
   .step(() => {});
 

--- a/features/analyzer/fixtures/valid-parsers.feature
+++ b/features/analyzer/fixtures/valid-parsers.feature
@@ -1,0 +1,7 @@
+Feature: Named variable placeholders
+
+  Scenario: Unquoted int and custom color placeholders match their steps
+    Given a user
+    And my favorite color is red
+    When I deposit 100 "USD"
+    Then everything was good

--- a/features/basic.feature
+++ b/features/basic.feature
@@ -32,3 +32,8 @@ Feature: Steps written in gherkin can be matched to Step Forge steps
     Scenario: A custom parser introduces a new placeholder type
         Given my favorite color is green
         Then the favorite color is green
+
+    Scenario: Steps can declare named variables and access them by name
+        Given a registered user named "Ada"
+        When I transfer "EUR" in the amount of 250
+        Then the transfer was 250 "EUR"

--- a/features/steps/analyzerSteps.ts
+++ b/features/steps/analyzerSteps.ts
@@ -18,14 +18,16 @@ const fixturesDir = path.resolve(__dirname, "../analyzer/fixtures");
 // --- Given: point at the fixture files to analyze --- //
 
 givenBuilder<AnalyzerGivenState>()
-  .statement((fileName: string) => `step definitions from ${fileName}`)
-  .step(({ variables: [fileName] }) => ({
+  .variables({ fileName: stringParser })
+  .statement(v => `step definitions from ${v.fileName}`)
+  .step(({ variables: { fileName } }) => ({
     stepFile: path.join(fixturesDir, fileName),
   }));
 
 givenBuilder<AnalyzerGivenState>()
-  .statement((fileName: string) => `a feature file ${fileName}`)
-  .step(({ variables: [fileName] }) => ({
+  .variables({ fileName: stringParser })
+  .statement(v => `a feature file ${v.fileName}`)
+  .step(({ variables: { fileName } }) => ({
     featureFile: path.join(fixturesDir, fileName),
   }));
 
@@ -52,31 +54,29 @@ thenBuilder<AnalyzerGivenState, AnalyzerWhenState, AnalyzerThenState>()
   });
 
 thenBuilder<AnalyzerGivenState, AnalyzerWhenState, AnalyzerThenState>()
-  .statement((count: number) => `there should be ${count} error/errors`)
-  .parsers([intParser])
+  .variables({ count: intParser })
+  .statement(v => `there should be ${v.count} error/errors`)
   .dependencies({ when: { diagnostics: "required" } })
-  .step(({ variables: [count], when: { diagnostics } }) => {
+  .step(({ variables: { count }, when: { diagnostics } }) => {
     const errors = diagnostics.filter(d => d.severity === "error");
     expect(errors).toHaveLength(count);
   });
 
 thenBuilder<AnalyzerGivenState, AnalyzerWhenState, AnalyzerThenState>()
-  .statement((substring: string) => `an error should mention ${substring}`)
+  .variables({ substring: stringParser })
+  .statement(v => `an error should mention ${v.substring}`)
   .dependencies({ when: { diagnostics: "required" } })
-  .step(({ variables: [substring], when: { diagnostics } }) => {
+  .step(({ variables: { substring }, when: { diagnostics } }) => {
     const errors = diagnostics.filter(d => d.severity === "error");
     const found = errors.some(e => e.message.includes(substring));
     expect(found).toEqual(true);
   });
 
 thenBuilder<AnalyzerGivenState, AnalyzerWhenState, AnalyzerThenState>()
-  .statement(
-    (count: number, rule: string) =>
-      `there is/are ${count} error/errors for rule ${rule}`
-  )
-  .parsers([intParser, stringParser])
+  .variables({ count: intParser, rule: stringParser })
+  .statement(v => `there is/are ${v.count} error/errors for rule ${v.rule}`)
   .dependencies({ when: { diagnostics: "required" } })
-  .step(({ variables: [count, rule], when: { diagnostics } }) => {
+  .step(({ variables: { count, rule }, when: { diagnostics } }) => {
     const errors = diagnostics.filter(
       d => d.severity === "error" && d.rule === rule
     );
@@ -84,13 +84,13 @@ thenBuilder<AnalyzerGivenState, AnalyzerWhenState, AnalyzerThenState>()
   });
 
 thenBuilder<AnalyzerGivenState, AnalyzerWhenState, AnalyzerThenState>()
+  .variables({ line: intParser, startCol: intParser, endCol: intParser })
   .statement(
-    (line: number, startCol: number, endCol: number) =>
-      `the error on line ${line} should span columns ${startCol} to ${endCol}`
+    v =>
+      `the error on line ${v.line} should span columns ${v.startCol} to ${v.endCol}`
   )
-  .parsers([intParser, intParser, intParser])
   .dependencies({ when: { diagnostics: "required" } })
-  .step(({ variables: [line, startCol, endCol], when: { diagnostics } }) => {
+  .step(({ variables: { line, startCol, endCol }, when: { diagnostics } }) => {
     const errors = diagnostics.filter(
       d => d.severity === "error" && d.range.startLine === line
     );

--- a/features/steps/commonSteps.ts
+++ b/features/steps/commonSteps.ts
@@ -13,7 +13,9 @@ import { expect } from "earl";
 
 // A custom parser introducing a brand-new `{color}` placeholder: only
 // `red|green|blue` match, so anything else is an undefined step at match time.
-const colorParser: Parser<Color> = {
+// The literal `"color"` name type makes named-variable hovers show
+// `Variable<Color, "color">` instead of `Variable<Color, string>`.
+const colorParser: Parser<Color, "color"> = {
   name: "color",
   regexp: /red|green|blue/,
   parse: raw => raw as Color,
@@ -92,8 +94,9 @@ thenBuilder<GivenState, WhenState, ThenState>()
 
 // --- Variable only steps --- //
 givenBuilder<GivenState>()
-  .statement((userName: string) => `a user named ${userName}`)
-  .step(({ variables: [userName] }) => {
+  .variables({ userName: stringParser })
+  .statement(v => `a user named ${v.userName}`)
+  .step(({ variables: { userName } }) => {
     return {
       user: {
         type: "person",
@@ -105,9 +108,10 @@ givenBuilder<GivenState>()
 // --- More complex steps --- //
 
 whenBuilder<GivenState, WhenState>()
-  .statement((userName: string) => `I name the user ${userName}`)
+  .variables({ userName: stringParser })
+  .statement(v => `I name the user ${v.userName}`)
   .dependencies({ given: { user: "required" } })
-  .step(({ given: { user }, variables: [userName] }) => {
+  .step(({ given: { user }, variables: { userName } }) => {
     return {
       user: {
         ...user,
@@ -118,9 +122,10 @@ whenBuilder<GivenState, WhenState>()
   });
 
 thenBuilder<GivenState, WhenState, ThenState>()
-  .statement((userName: string) => `the user's name is ${userName}`)
+  .variables({ userName: stringParser })
+  .statement(v => `the user's name is ${v.userName}`)
   .dependencies({ when: { user: "required" } })
-  .step(({ when: { user }, variables: [userName] }) => {
+  .step(({ when: { user }, variables: { userName } }) => {
     const token = user.token;
     expect(token).toEqual(userName);
   });
@@ -128,12 +133,10 @@ thenBuilder<GivenState, WhenState, ThenState>()
 // --- Unquoted number variables (parsers) --- //
 
 whenBuilder<GivenState, WhenState>()
-  .statement(
-    (amount: number, currency: string) => `I deposit ${amount} ${currency}`
-  )
-  .parsers([intParser, stringParser])
+  .variables({ amount: intParser, currency: stringParser })
+  .statement(v => `I deposit ${v.amount} ${v.currency}`)
   .dependencies({ given: { user: "required" } })
-  .step(({ variables: [amount, currency], given: { user } }) => {
+  .step(({ variables: { amount, currency }, given: { user } }) => {
     return {
       deposit: {
         amount,
@@ -144,10 +147,10 @@ whenBuilder<GivenState, WhenState>()
   });
 
 thenBuilder<GivenState, WhenState, ThenState>()
-  .statement((amount: number) => `the deposit amount is ${amount}`)
-  .parsers([intParser])
+  .variables({ amount: intParser })
+  .statement(v => `the deposit amount is ${v.amount}`)
   .dependencies({ when: { deposit: "required" } })
-  .step(({ variables: [amount], when: { deposit } }) => {
+  .step(({ variables: { amount }, when: { deposit } }) => {
     expect(deposit.amount).toEqual(amount);
     expect(typeof deposit.amount).toEqual("number");
   });
@@ -155,16 +158,52 @@ thenBuilder<GivenState, WhenState, ThenState>()
 // --- Custom parser (novel {color} placeholder) --- //
 
 givenBuilder<GivenState>()
-  .statement((color: Color) => `my favorite color is ${color}`)
-  .parsers([colorParser])
-  .step(({ variables: [color] }) => ({ favoriteColor: color }));
+  .variables({ color: colorParser })
+  .statement(v => `my favorite color is ${v.color}`)
+  .step(({ variables: { color } }) => ({ favoriteColor: color }));
 
 thenBuilder<GivenState, WhenState, ThenState>()
-  .statement((color: Color) => `the favorite color is ${color}`)
-  .parsers([colorParser])
+  .variables({ color: colorParser })
+  .statement(v => `the favorite color is ${v.color}`)
   .dependencies({ given: { favoriteColor: "required" } })
-  .step(({ variables: [color], given: { favoriteColor } }) => {
+  .step(({ variables: { color }, given: { favoriteColor } }) => {
     expect(favoriteColor).toEqual(color);
+  });
+
+// --- Declaration order vs interpolation order --- //
+
+givenBuilder<GivenState>()
+  .variables({ userName: stringParser })
+  .statement(v => `a registered user named ${v.userName}`)
+  .step(({ variables: { userName } }) => ({
+    user: {
+      type: "person",
+      token: userName,
+    },
+  }));
+
+// Interpolation order (currency before amount) deliberately differs from the
+// declaration order — the runtime maps captures by interpolation, not by key.
+whenBuilder<GivenState, WhenState>()
+  .variables({ amount: intParser, currency: stringParser })
+  .statement(v => `I transfer ${v.currency} in the amount of ${v.amount}`)
+  .dependencies({ given: { user: "required" } })
+  .step(({ variables: { amount, currency }, given: { user } }) => ({
+    deposit: {
+      amount,
+      currency,
+      user,
+    },
+  }));
+
+thenBuilder<GivenState, WhenState, ThenState>()
+  .variables({ amount: intParser, currency: stringParser })
+  .statement(v => `the transfer was ${v.amount} ${v.currency}`)
+  .dependencies({ when: { deposit: "required" } })
+  .step(({ variables: { amount, currency }, when: { deposit } }) => {
+    expect(deposit.amount).toEqual(amount);
+    expect(typeof amount).toEqual("number");
+    expect(deposit.currency).toEqual(currency);
   });
 
 // --- Hook observation step --- //

--- a/features/steps/exportedSteps.ts
+++ b/features/steps/exportedSteps.ts
@@ -1,12 +1,15 @@
 import { expect } from "earl";
-import { givenBuilder } from "../../src/given";
-import { thenBuilder } from "../../src/then";
-import { whenBuilder } from "../../src/when";
+import { createBuilders } from "../../src/init";
+import { numberParser, stringParser } from "../../src/parsers";
 import { GivenState, ThenState, WhenState } from "./world";
 
-const Given = givenBuilder<GivenState>().statement;
-const When = whenBuilder<GivenState, WhenState>().statement;
-const Then = thenBuilder<GivenState, WhenState, ThenState>().statement;
+// Demo of the pre-bound builder style: `Given("...")` for plain statements,
+// `Given.variables({...}).statement(v => ...)` for statements with variables.
+const { Given, When, Then } = createBuilders<
+  GivenState,
+  WhenState,
+  ThenState
+>();
 
 Given("a bank user").step(() => {
   return {
@@ -17,10 +20,10 @@ Given("a bank user").step(() => {
   };
 });
 
-When((amount: string, currency: string) => `I deposit ${amount} ${currency}`)
+When.variables({ amount: numberParser, currency: stringParser })
+  .statement(v => `I deposit ${v.amount} ${v.currency}`)
   .dependencies({ given: { user: "required" } })
-  .step(({ variables: [rawAmount, currency], given: { user } }) => {
-    const amount = parseFloat(rawAmount);
+  .step(({ variables: { amount, currency }, given: { user } }) => {
     return {
       deposit: {
         amount,
@@ -30,9 +33,9 @@ When((amount: string, currency: string) => `I deposit ${amount} ${currency}`)
     };
   });
 
-Then((amount: string) => `the balance is ${amount}`)
+Then.variables({ amount: numberParser })
+  .statement(v => `the balance is ${v.amount}`)
   .dependencies({ when: { deposit: "required" } })
-  .step(({ when: { deposit }, variables: [rawAmount] }) => {
-    const amount = parseFloat(rawAmount);
+  .step(({ when: { deposit }, variables: { amount } }) => {
     expect(deposit.amount).toEqual(amount);
   });

--- a/features/steps/placeholderSteps.ts
+++ b/features/steps/placeholderSteps.ts
@@ -2,46 +2,51 @@ import { expect } from "earl";
 import { givenBuilder } from "../../src/given";
 import { thenBuilder } from "../../src/then";
 import { whenBuilder } from "../../src/when";
-import { intParser } from "../../src/parsers";
+import { intParser, stringParser } from "../../src/parsers";
 import { GivenState, ThenState, WhenState } from "./world";
 
-// These steps build (but never register) other steps so we can inspect the
-// Cucumber expression that Step Forge resolves from the statement + parsers.
+// These steps build (and, as a side effect of `.step()`, register) other steps
+// so we can inspect the Cucumber expression that Step Forge resolves from the
+// variables map + statement.
 
 thenBuilder<GivenState, WhenState, ThenState>()
-  .statement(
-    "a step with a variable and no parsers uses the string placeholder"
-  )
+  .statement("a step with a string variable uses the string placeholder")
   .step(() => {
     const built = givenBuilder<GivenState>()
-      .statement((userName: string) => `a user named ${userName}`)
-      .step(({ variables: [userName] }) => ({
+      .variables({ userName: stringParser })
+      .statement(v => `a user named ${v.userName}`)
+      .step(({ variables: { userName } }) => ({
         user: { type: "person", token: userName },
       }));
-    expect(built.expression).toEqual("a user named {string}");
+    // `expression` is literal-typed from the statement: the annotation is
+    // checked at compile time, the assertion at run time.
+    const expression: `a user named ${string}` = built.expression;
+    expect(expression).toEqual("a user named {string}");
   });
 
 thenBuilder<GivenState, WhenState, ThenState>()
   .statement("a step with an int parser uses the int placeholder")
   .step(() => {
     const built = whenBuilder<GivenState, WhenState>()
-      .statement((amount: number) => `I deposit ${amount}`)
-      .parsers([intParser])
-      .step(({ variables: [amount] }) => ({
+      .variables({ amount: intParser })
+      .statement(v => `I deposit ${v.amount}`)
+      .step(({ variables: { amount } }) => ({
         deposit: {
           amount,
           currency: "USD",
           user: { type: "person", token: "random" },
         },
       }));
-    expect(built.expression).toEqual("I deposit {int}");
+    const expression: `I deposit ${string}` = built.expression;
+    expect(expression).toEqual("I deposit {int}");
   });
 
 thenBuilder<GivenState, WhenState, ThenState>()
-  .statement((value: string) => `an unparsed value of ${value} is a string`)
-  .step(({ variables: [value] }) => {
-    // No parsers declared, so the value is passed through unchanged rather
-    // than being coerced to a number.
+  .variables({ value: stringParser })
+  .statement(v => `a string-parsed value of ${v.value} is a string`)
+  .step(({ variables: { value } }) => {
+    // The string parser passes the (unquoted) value through unchanged rather
+    // than coercing it to a number.
     expect(typeof value).toEqual("string");
     expect(value).toEqual("100");
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@step-forge/step-forge",
-  "version": "0.0.27-alpha.1",
+  "version": "0.0.27-alpha.2",
   "module": "./dist/step-forge.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@step-forge/step-forge",
-  "version": "0.0.26",
+  "version": "0.0.27-alpha.1",
   "module": "./dist/step-forge.js",
   "type": "module",
   "exports": {

--- a/src/analyzer/stepExtractor.test.ts
+++ b/src/analyzer/stepExtractor.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractStepDefinitions } from "./stepExtractor";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureStepFile = path.resolve(
+  __dirname,
+  "../../features/analyzer/fixtures/steps.ts"
+);
+
+describe("extractStepDefinitions", () => {
+  const definitions = extractStepDefinitions([fixtureStepFile]);
+  const expressions = definitions.map(d => d.expression);
+
+  it("extracts plain string statements verbatim", () => {
+    expect(expressions).toContain("I started");
+    expect(expressions).toContain("a user");
+  });
+
+  it("extracts a string variable as {string}", () => {
+    expect(expressions).toContain("a user named {string}");
+    expect(expressions).toContain("the user's name is {string}");
+  });
+
+  it("extracts non-string builtin parsers with their exact placeholders", () => {
+    // Previously every hole was hardcoded to {string}; the variables map must
+    // now drive the placeholder per hole, in interpolation order.
+    expect(expressions).toContain("I deposit {int} {string}");
+  });
+
+  it("resolves a same-file custom parser's placeholder from its declaration", () => {
+    expect(expressions).toContain("my favorite color is {color}");
+  });
+
+  it("keeps step types and dependencies intact through the variables chain", () => {
+    const deposit = definitions.find(
+      d => d.expression === "I deposit {int} {string}"
+    );
+    expect(deposit?.stepType).toBe("when");
+    expect(deposit?.dependencies.given).toEqual({ user: "required" });
+  });
+
+  it("extracts a custom parser's regex pattern for the matcher", () => {
+    const color = definitions.find(
+      d => d.expression === "my favorite color is {color}"
+    );
+    expect(color?.parameters).toEqual({ color: "red|green|blue" });
+  });
+
+  it("emits no parameters for steps using only builtin parsers", () => {
+    const deposit = definitions.find(
+      d => d.expression === "I deposit {int} {string}"
+    );
+    expect(deposit?.parameters).toBeUndefined();
+  });
+});

--- a/src/analyzer/stepExtractor.ts
+++ b/src/analyzer/stepExtractor.ts
@@ -146,7 +146,8 @@ function extractFromRegisterCall(
   const chain = collectCallChain(registerCall);
 
   let stepType: StepType | null = null;
-  let expression: string | null = null;
+  let statementCall: ts.CallExpression | null = null;
+  let variablesCall: ts.CallExpression | null = null;
   let dependencies: StepDefinitionMeta["dependencies"] = {
     given: {},
     when: {},
@@ -174,8 +175,13 @@ function extractFromRegisterCall(
     }
 
     if (name === "statement") {
-      expression = extractExpression(link);
+      statementCall = link;
       // Try to find the builder type by continuing up the chain
+      continue;
+    }
+
+    if (name === "variables") {
+      variablesCall = link;
       continue;
     }
 
@@ -185,6 +191,18 @@ function extractFromRegisterCall(
       continue;
     }
   }
+
+  // The expression needs the whole chain: the statement supplies the text and
+  // the interpolation order, the variables map supplies each hole's placeholder
+  // (and, for custom parsers, the regex pattern the matcher should enforce).
+  const { placeholders, parameters } = extractPlaceholderMap(
+    variablesCall,
+    sourceFile,
+    ctx
+  );
+  let expression: string | null = statementCall
+    ? extractExpression(statementCall, placeholders)
+    : null;
 
   // If we didn't find the builder or expression in the chain, try the "re-exported" pattern:
   // const Given = givenBuilder<T>().statement;
@@ -211,6 +229,7 @@ function extractFromRegisterCall(
     produces,
     sourceFile: sourceFile.fileName,
     line,
+    ...(Object.keys(parameters).length > 0 ? { parameters } : {}),
   };
 }
 
@@ -253,27 +272,271 @@ function getCallName(call: ts.CallExpression): string | null {
   return null;
 }
 
-function extractExpression(statementCall: ts.CallExpression): string | null {
+/**
+ * The placeholder each built-in parser renders. Recognised by export name so
+ * the common case (`.variables({ amount: intParser })`) resolves on the
+ * parse-only fast path with no type information at all.
+ */
+const BUILTIN_PARSER_PLACEHOLDERS: Record<string, string> = {
+  stringParser: "string",
+  intParser: "int",
+  numberParser: "float",
+  booleanParser: "boolean",
+};
+
+function extractExpression(
+  statementCall: ts.CallExpression,
+  placeholders: Map<string, string>
+): string | null {
   const arg = statementCall.arguments[0];
   if (!arg) return null;
 
   // String literal: .statement("a user")
-  if (ts.isStringLiteral(arg)) {
+  if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
     return arg.text;
   }
 
-  // Arrow function with template literal: .statement((name: string) => `a user named ${name}`)
+  // Token statement: .variables({name: parser}).statement(v => `a ${v.name}`)
   if (ts.isArrowFunction(arg)) {
-    return extractExpressionFromArrowFunction(arg);
+    return extractExpressionFromArrowFunction(arg, placeholders);
   }
 
   return null;
 }
 
-function extractExpressionFromArrowFunction(
-  fn: ts.ArrowFunction
+/** What a parser expression resolves to: its placeholder name and, when the
+ *  declaration's `regexp` is statically visible, the regex pattern to enforce. */
+interface ResolvedParser {
+  placeholder: string;
+  pattern?: string;
+}
+
+/**
+ * Resolve the `.variables()` map into variable name → placeholder name
+ * (`amount` → `int`) plus a placeholder → regex-pattern record for custom
+ * parsers. An entry whose parser can't be resolved is simply absent — the
+ * template reconstruction falls back to `{string}` for it (after requesting a
+ * type-checked retry if one hasn't happened yet).
+ */
+function extractPlaceholderMap(
+  variablesCall: ts.CallExpression | null,
+  sourceFile: ts.SourceFile,
+  ctx: ExtractCtx
+): { placeholders: Map<string, string>; parameters: Record<string, string> } {
+  const placeholders = new Map<string, string>();
+  const parameters: Record<string, string> = {};
+  const arg = variablesCall?.arguments[0];
+  if (!arg || !ts.isObjectLiteralExpression(arg)) {
+    return { placeholders, parameters };
+  }
+
+  for (const prop of arg.properties) {
+    let varName: string | null = null;
+    let parserExpr: ts.Expression | null = null;
+    if (
+      ts.isPropertyAssignment(prop) &&
+      (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name))
+    ) {
+      varName = prop.name.text;
+      parserExpr = prop.initializer;
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      varName = prop.name.text;
+      parserExpr = prop.name;
+    }
+    if (!varName || !parserExpr) continue;
+
+    const resolved = resolveParser(parserExpr, sourceFile, ctx);
+    if (resolved) {
+      placeholders.set(varName, resolved.placeholder);
+      if (resolved.pattern) parameters[resolved.placeholder] = resolved.pattern;
+    }
+  }
+  return { placeholders, parameters };
+}
+
+/**
+ * Resolve a parser expression to its placeholder (the `name` property) and,
+ * when visible, its regex pattern. Resolution order: built-in parsers by
+ * export name, an inline object literal, a same-file `const` declaration, and
+ * finally the type checker (the `name` property of a `Parser<T, "name">` is a
+ * string literal type — but `regexp` is a runtime value, so the checker branch
+ * yields no pattern). The checker branch is what makes parsers imported from
+ * other modules work; on the parse-only pass it flags `needsChecker` for the
+ * one-time retry.
+ */
+function resolveParser(
+  expr: ts.Expression,
+  sourceFile: ts.SourceFile,
+  ctx: ExtractCtx
+): ResolvedParser | null {
+  if (ts.isObjectLiteralExpression(expr)) {
+    return parserFromObjectLiteral(expr);
+  }
+
+  if (ts.isIdentifier(expr)) {
+    const builtin = BUILTIN_PARSER_PLACEHOLDERS[expr.text];
+    if (builtin) return { placeholder: builtin };
+
+    const local = parserFromLocalDeclaration(expr.text, sourceFile);
+    if (local) return local;
+  }
+
+  if (!ctx.checker) {
+    ctx.needsChecker = true;
+    return null;
+  }
+  try {
+    const type = ctx.checker.getTypeAtLocation(expr);
+    const nameSymbol = type.getProperty("name");
+    if (nameSymbol) {
+      const nameType = ctx.checker.getTypeOfSymbolAtLocation(nameSymbol, expr);
+      if (nameType.isStringLiteral()) return { placeholder: nameType.value };
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+/** Resolve a parser object literal: `name` (required) and `regexp` (optional). */
+function parserFromObjectLiteral(
+  obj: ts.ObjectLiteralExpression
+): ResolvedParser | null {
+  let placeholder: string | null = null;
+  let pattern: string | undefined;
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+    if (prop.name.text === "name" && ts.isStringLiteral(prop.initializer)) {
+      placeholder = prop.initializer.text;
+    }
+    if (prop.name.text === "regexp") {
+      pattern = regexPatternFromExpression(prop.initializer);
+    }
+  }
+  return placeholder ? { placeholder, pattern } : null;
+}
+
+/**
+ * The regex source of a parser's `regexp` property: a regex literal's pattern,
+ * or the `|`-joined patterns of an array of regex literals (mirroring how the
+ * engine offers each as an alternative). Anything non-literal is skipped.
+ */
+function regexPatternFromExpression(expr: ts.Expression): string | undefined {
+  if (ts.isRegularExpressionLiteral(expr)) {
+    return regexSource(expr.text);
+  }
+  if (ts.isArrayLiteralExpression(expr)) {
+    const sources = expr.elements
+      .filter(ts.isRegularExpressionLiteral)
+      .map(el => regexSource(el.text));
+    if (sources.length === expr.elements.length && sources.length > 0) {
+      return sources.map(s => `(?:${s})`).join("|");
+    }
+  }
+  return undefined;
+}
+
+/** `/pattern/flags` → `pattern`. */
+function regexSource(literalText: string): string {
+  return literalText.slice(1, literalText.lastIndexOf("/"));
+}
+
+/**
+ * Syntactic same-file lookup for a custom parser: find
+ * `const colorParser = { name: "color", regexp: ..., ... }` (possibly behind
+ * `as`/`satisfies`/parens) and resolve it.
+ */
+function parserFromLocalDeclaration(
+  identifierName: string,
+  sourceFile: ts.SourceFile
+): ResolvedParser | null {
+  let found: ResolvedParser | null = null;
+  function visit(node: ts.Node) {
+    if (found) return;
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === identifierName &&
+      node.initializer
+    ) {
+      let init: ts.Expression = node.initializer;
+      while (
+        ts.isAsExpression(init) ||
+        ts.isSatisfiesExpression(init) ||
+        ts.isParenthesizedExpression(init)
+      ) {
+        init = init.expression;
+      }
+      if (ts.isObjectLiteralExpression(init)) {
+        found = parserFromObjectLiteral(init);
+      }
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * How the statement function binds its token object: a plain parameter
+ * (`v => ... ${v.amount}`) or a destructuring pattern
+ * (`({ amount }) => ... ${amount}`, renames included). Used to map each
+ * template hole back to its declared variable name.
+ */
+type TokenBinding =
+  | { kind: "identifier"; name: string }
+  | { kind: "destructured"; localToVariable: Map<string, string> };
+
+function tokenBindingOf(fn: ts.ArrowFunction): TokenBinding | null {
+  const param = fn.parameters[0];
+  if (!param) return { kind: "identifier", name: "" };
+  if (ts.isIdentifier(param.name)) {
+    return { kind: "identifier", name: param.name.text };
+  }
+  if (ts.isObjectBindingPattern(param.name)) {
+    const localToVariable = new Map<string, string>();
+    for (const element of param.name.elements) {
+      if (!ts.isIdentifier(element.name)) continue;
+      const local = element.name.text;
+      const declared =
+        element.propertyName && ts.isIdentifier(element.propertyName)
+          ? element.propertyName.text
+          : local;
+      localToVariable.set(local, declared);
+    }
+    return { kind: "destructured", localToVariable };
+  }
+  return null;
+}
+
+/** The declared variable name a template hole refers to, or null. */
+function tokenVariableName(
+  expr: ts.Expression,
+  binding: TokenBinding
 ): string | null {
-  const params = fn.parameters.map(p => p.name.getText());
+  if (binding.kind === "identifier") {
+    if (
+      ts.isPropertyAccessExpression(expr) &&
+      ts.isIdentifier(expr.expression) &&
+      expr.expression.text === binding.name
+    ) {
+      return expr.name.text;
+    }
+    return null;
+  }
+  if (ts.isIdentifier(expr)) {
+    return binding.localToVariable.get(expr.text) ?? null;
+  }
+  return null;
+}
+
+function extractExpressionFromArrowFunction(
+  fn: ts.ArrowFunction,
+  placeholders: Map<string, string>
+): string | null {
+  const binding = tokenBindingOf(fn);
+  if (!binding) return null;
 
   // The body should be a template expression or string literal
   let body = fn.body;
@@ -289,10 +552,14 @@ function extractExpressionFromArrowFunction(
   }
 
   if (ts.isTemplateExpression(body)) {
-    return reconstructExpressionFromTemplate(body, params);
+    return reconstructExpressionFromTemplate(body, binding, placeholders);
   }
 
   if (ts.isNoSubstitutionTemplateLiteral(body)) {
+    return body.text;
+  }
+
+  if (ts.isStringLiteral(body)) {
     return body.text;
   }
 
@@ -301,20 +568,18 @@ function extractExpressionFromArrowFunction(
 
 function reconstructExpressionFromTemplate(
   template: ts.TemplateExpression,
-  paramNames: string[]
+  binding: TokenBinding,
+  placeholders: Map<string, string>
 ): string {
   let result = template.head.text;
 
   for (const span of template.templateSpans) {
-    if (
-      ts.isIdentifier(span.expression) &&
-      paramNames.includes(span.expression.text)
-    ) {
-      result += "{string}";
-    } else {
-      // Non-parameter expression, use {string} as fallback
-      result += "{string}";
-    }
+    const varName = tokenVariableName(span.expression, binding);
+    const placeholder = varName ? placeholders.get(varName) : undefined;
+    // A hole whose parser couldn't be resolved falls back to {string}; the
+    // unresolved-parser path has already requested a type-checked retry, so
+    // this only sticks when even the checker can't name the placeholder.
+    result += `{${placeholder ?? "string"}}`;
     result += span.literal.text;
   }
 
@@ -489,8 +754,9 @@ function resolveReExportedCall(
     if (ts.isCallExpression(callExpr)) {
       const callee = callExpr.expression;
       if (ts.isIdentifier(callee) && BUILDER_NAMES[callee.text]) {
-        // The lastCall IS the statement call — extract expression from it
-        const expression = extractExpression(lastCall);
+        // The lastCall IS the statement call — extract expression from it.
+        // Re-exported statements are plain strings, so no variables map.
+        const expression = extractExpression(lastCall, new Map());
         return {
           stepType: BUILDER_NAMES[callee.text],
           expression,

--- a/src/analyzer/stepMatcher.test.ts
+++ b/src/analyzer/stepMatcher.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { findMatchingDefinitions } from "./stepMatcher";
+import { StepDefinitionMeta } from "./types";
+
+const def = (
+  stepType: StepDefinitionMeta["stepType"],
+  expression: string,
+  parameters?: Record<string, string>
+): StepDefinitionMeta => ({
+  stepType,
+  expression,
+  dependencies: { given: {}, when: {}, then: {} },
+  produces: [],
+  sourceFile: "steps.ts",
+  line: 1,
+  ...(parameters ? { parameters } : {}),
+});
+
+describe("stepMatcher placeholder patterns", () => {
+  const deposit = def("when", "I deposit {int} {string}");
+
+  it("{int} matches integers only", () => {
+    expect(
+      findMatchingDefinitions('I deposit 100 "USD"', "When", [deposit])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions('I deposit -5 "USD"', "When", [deposit])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions('I deposit ten "USD"', "When", [deposit])
+    ).toHaveLength(0);
+    expect(
+      findMatchingDefinitions('I deposit 1.5 "USD"', "When", [deposit])
+    ).toHaveLength(0);
+  });
+
+  it("{string} requires a quoted value", () => {
+    expect(
+      findMatchingDefinitions("I deposit 100 USD", "When", [deposit])
+    ).toHaveLength(0);
+    expect(
+      findMatchingDefinitions("I deposit 100 'USD'", "When", [deposit])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions('I deposit 100 "US \\"D\\""', "When", [deposit])
+    ).toHaveLength(1);
+  });
+
+  it("{float} matches decimal numbers", () => {
+    const price = def("then", "the price is {float}");
+    expect(
+      findMatchingDefinitions("the price is 19.99", "Then", [price])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions("the price is 19", "Then", [price])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions("the price is nineteen", "Then", [price])
+    ).toHaveLength(0);
+  });
+
+  it("{boolean} matches true/false only", () => {
+    const flag = def("then", "the flag is {boolean}");
+    expect(
+      findMatchingDefinitions("the flag is true", "Then", [flag])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions("the flag is false", "Then", [flag])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions("the flag is maybe", "Then", [flag])
+    ).toHaveLength(0);
+  });
+
+  it("custom placeholders enforce their extracted pattern", () => {
+    const color = def("given", "my favorite color is {color}", {
+      color: "red|green|blue",
+    });
+    expect(
+      findMatchingDefinitions("my favorite color is red", "Given", [color])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions("my favorite color is purple", "Given", [color])
+    ).toHaveLength(0);
+  });
+
+  it("a custom placeholder without an extracted pattern matches any text", () => {
+    const color = def("given", "my favorite color is {color}");
+    expect(
+      findMatchingDefinitions("my favorite color is purple", "Given", [color])
+    ).toHaveLength(1);
+  });
+
+  it("matching is case-sensitive like the runtime engine", () => {
+    const user = def("given", "a user");
+    expect(findMatchingDefinitions("a user", "Given", [user])).toHaveLength(1);
+    expect(findMatchingDefinitions("A User", "Given", [user])).toHaveLength(0);
+  });
+
+  it("literal regex characters in expressions stay literal", () => {
+    const parens = def("given", "a user (admin) with $5");
+    expect(
+      findMatchingDefinitions("a user (admin) with $5", "Given", [parens])
+    ).toHaveLength(1);
+    expect(
+      findMatchingDefinitions("a user admin with $5", "Given", [parens])
+    ).toHaveLength(0);
+  });
+});

--- a/src/analyzer/stepMatcher.ts
+++ b/src/analyzer/stepMatcher.ts
@@ -5,22 +5,53 @@ interface CompiledPattern {
   definition: StepDefinitionMeta;
 }
 
+/**
+ * What each built-in placeholder actually matches, mirroring the runtime
+ * engine's parameter types: `{string}` is a quoted value (escapes allowed),
+ * `{int}`/`{float}` are numeric, `{boolean}` is `true`/`false`. Equivalent to
+ * the `src/parsers.ts` regexps; the matcher unit tests pin the behavior.
+ */
+const BUILTIN_PLACEHOLDER_PATTERNS: Record<string, string> = {
+  string: `"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'`,
+  int: "-?\\d+",
+  float: "-?\\d*\\.?\\d+",
+  boolean: "true|false",
+};
+
+/**
+ * Compile a step expression into an anchored, case-sensitive regex whose
+ * placeholders match by their real syntax: the extracted parser pattern for a
+ * custom placeholder (`def.parameters`), the built-in pattern for
+ * `{string}`/`{int}`/`{float}`/`{boolean}`, and `.+` only as the last resort
+ * for a placeholder the extractor couldn't resolve. This is what lets the
+ * analyzer catch a step whose text can't actually satisfy its parsers (e.g.
+ * `I deposit ten` against `I deposit {int}`) instead of silently matching.
+ */
+function compileExpression(def: StepDefinitionMeta): RegExp {
+  const parts = def.expression.split(/(\{[^}]*\})/);
+  let regexStr = "";
+  for (const part of parts) {
+    const placeholder = /^\{([^}]*)\}$/.exec(part);
+    if (placeholder) {
+      const name = placeholder[1];
+      const pattern =
+        def.parameters?.[name] ?? BUILTIN_PLACEHOLDER_PATTERNS[name] ?? ".+";
+      regexStr += `(${pattern})`;
+    } else {
+      regexStr += part.replace(/[.*+?^$()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${regexStr}$`);
+}
+
 function compileDefinitions(
   definitions: StepDefinitionMeta[]
 ): CompiledPattern[] {
   const compiled: CompiledPattern[] = [];
   for (const def of definitions) {
     try {
-      // Replace {paramType} placeholders with (.+) to match any value,
-      // regardless of which parser placeholder ({string}, {int}, ...) the
-      // step definition declared.
-      const placeholder = "###PLACEHOLDER###";
-      const regexStr = def.expression
-        .replace(/\{[^}]+\}/g, placeholder)
-        .replace(/[.*+?^$()|[\]\\]/g, "\\$&")
-        .replace(new RegExp(placeholder, "g"), "(.+)");
       compiled.push({
-        regex: new RegExp(`^${regexStr}$`, "i"),
+        regex: compileExpression(def),
         definition: def,
       });
     } catch {

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -9,6 +9,15 @@ export interface StepDefinitionMeta {
   produces: string[];
   sourceFile: string;
   line: number;
+  /**
+   * Regex source per custom placeholder used in `expression` (e.g.
+   * `{ color: "red|green|blue" }`), extracted from the parser declaration's
+   * `regexp` property when it is statically visible. The matcher uses these to
+   * constrain matching exactly like the runtime engine; built-in placeholders
+   * (`{string}`/`{int}`/`{float}`/`{boolean}`) don't need an entry, and a
+   * custom placeholder without one falls back to matching any text.
+   */
+  parameters?: Record<string, string>;
 }
 
 export interface ParsedScenario {

--- a/src/builderTypeUtils.ts
+++ b/src/builderTypeUtils.ts
@@ -26,11 +26,3 @@ export type Restrict<State, Deps extends RequiredOrOptional<State>> = {
     K in keyof State as K extends keyof Deps ? K : never
   ]: Deps[K] extends "optional" ? State[K] | undefined : State[K];
 };
-
-export type GetFunctionArgs<T> = T extends (...args: infer A) => any
-  ? A
-  : never;
-
-export const isString = (
-  statement: string | ((...args: [...any]) => string)
-): statement is string => typeof statement === "string";

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DepMap, FullDependencies, StepType } from "./builderTypeUtils";
-import { Parser, stringParser } from "./parsers";
+import { Parser } from "./parsers";
 import { globalRegistry } from "./runtime/registry";
 import { captureDefinitionSite } from "./sourceLocation";
+import { renderNamedExpression, VariableMap } from "./variables";
 import { MergeableWorld } from "./world";
 
 /**
@@ -47,41 +48,55 @@ const requiredKeysOf = (deps: DepMap): string[] =>
   Object.keys(deps).filter(key => deps[key] === "required");
 
 /**
- * The runtime core of the builder chain. `addStep` is deliberately phase-agnostic:
- * the calling builder (given/when/then) has already computed the exact type of the
- * step function via its two type parameters:
+ * Everything the registration core needs beyond the step function itself.
+ * Built by `addStep`; `registerStep` is the shared registration tail.
+ */
+type StepRuntimeConfig = {
+  statement: (...args: any[]) => string;
+  /** The finished cucumber expression, placeholders already rendered. */
+  expression: string;
+  /** Parsers in capture-group order — exactly what the engine registers. */
+  parsers: Parser<any>[];
+  /**
+   * Shape the matcher's positional captures into the name-keyed `variables`
+   * object the step function sees.
+   */
+  toVariables: (capturedArgs: unknown[]) => unknown;
+  stepType: StepType;
+  dependencies: FullDependencies;
+};
+
+/**
+ * The runtime core of the builder chain, phase-agnostic: the calling builder
+ * has already computed the exact type of the step function via the type
+ * parameters:
  *
  * - `StepFnInput`  — the `{ variables, given, when, then }` object the step receives,
  *   with each phase already narrowed to its declared dependencies.
  * - `StepFnOutput` — the phase-appropriate return type (`Partial<State>`, or `void`).
+ * - `Expr`         — the statement's compile-time text: the exact literal for a
+ *   string statement, a `${string}`-holed template type for a token statement.
+ *   The returned metadata's `expression` carries it.
  *
- * Everything else is plain runtime data (a statement function, the step type, the
- * dependency map, the parsers), so `addStep` carries no generics for them.
+ * Everything else is plain runtime data carried in the config, so `registerStep`
+ * carries no generics for it.
  */
-export const addStep =
-  <StepFnInput, StepFnOutput>(
-    statement: (...args: any[]) => string,
-    stepType: StepType,
-    dependencies: FullDependencies = {
-      given: {},
-      when: {},
-      then: {},
-    },
-    declaredParsers?: Parser<any>[]
-  ) =>
+const registerStep =
+  <StepFnInput, StepFnOutput, Expr extends string>(config: StepRuntimeConfig) =>
   (stepFunction: (input: StepFnInput) => StepFnOutput) => {
+    const {
+      statement,
+      expression,
+      parsers,
+      toVariables,
+      stepType,
+      dependencies,
+    } = config;
     const {
       given: givenDependencies,
       when: whenDependencies,
       then: thenDependencies,
     } = dependencies;
-    // Resolve the parsers up front, defaulting every variable to `stringParser`
-    // (the `{string}` placeholder, value passed through unchanged) when none are
-    // provided. Numeric/boolean values are opt-in via explicit parsers.
-    const argCount = statement.length;
-    const parsers =
-      declaredParsers ?? Array.from({ length: argCount }, () => stringParser);
-    const expression = statement(...parsers.map(parser => `{${parser.name}}`));
     // Dependency key lists are fixed once the step is registered, so compute
     // them here (once) rather than on every execution. `*AllKeys` is every
     // declared dependency (required + optional), `*RequiredKeys` the subset that
@@ -103,7 +118,7 @@ export const addStep =
       capturedArgs: unknown[]
     ) => {
       const result = await stepFunction({
-        variables: capturedArgs,
+        variables: toVariables(capturedArgs),
         given: narrowPhase(world, "given", givenAllKeys, givenRequiredKeys),
         when: narrowPhase(world, "when", whenAllKeys, whenRequiredKeys),
         then: narrowPhase(world, "then", thenAllKeys, thenRequiredKeys),
@@ -124,9 +139,44 @@ export const addStep =
 
     return {
       statement,
-      expression,
+      expression: expression as Expr,
       dependencies,
       stepType,
       stepFunction,
     };
   };
+
+/**
+ * Registration for the builder chain: the `.variables()` map declares
+ * name → parser, the statement interpolates opaque tokens (a string statement
+ * is normalized by the builder to `() => statement` with an empty map), and
+ * the step function receives `variables` as a name-keyed object. The token
+ * dance in `renderNamedExpression` recovers the interpolation order, which is
+ * the bridge between the matcher's positional captures and the named object.
+ */
+export const addStep = <StepFnInput, StepFnOutput, Expr extends string>(
+  statement: (tokens: any) => string,
+  stepType: StepType,
+  dependencies: FullDependencies = {
+    given: {},
+    when: {},
+    then: {},
+  },
+  variables: VariableMap = {}
+) => {
+  const { expression, order } = renderNamedExpression(statement, variables);
+  return registerStep<StepFnInput, StepFnOutput, Expr>({
+    statement,
+    expression,
+    parsers: order.map(name => variables[name]),
+    toVariables: capturedArgs => {
+      const named: Record<string, unknown> = {};
+      for (let i = 0; i < order.length; i++) {
+        named[order[i]] = capturedArgs[i];
+      }
+      return named;
+    },
+    stepType,
+    dependencies,
+  });
+};

--- a/src/given.ts
+++ b/src/given.ts
@@ -2,14 +2,17 @@
 
 import {
   FullDependencies,
-  GetFunctionArgs,
-  isString,
   RequiredOrOptional,
   Restrict,
   StepType,
 } from "./builderTypeUtils";
 import { addStep } from "./common";
-import { Parser } from "./parsers";
+import {
+  NoVariables,
+  VariableMap,
+  VariablesOf,
+  VariableTokens,
+} from "./variables";
 
 const GIVEN: StepType = "given";
 
@@ -26,66 +29,73 @@ type GivenInput<Variables, Given> = {
 type GivenOutput<GivenState> =
   Partial<GivenState> | Promise<Partial<GivenState>>;
 
+// Shared dependencies stage for both entry styles. `Variables` is already the
+// resolved shape the step function sees (`VariablesOf<Map>` for a token
+// statement, `NoVariables` for a string statement), so this stage carries no
+// map generics of its own.
 const givenDependencies =
-  <Variables, GivenState>(
-    statement: (...args: any[]) => string,
-    parsers?: Parser<any>[]
+  <Variables, Expr extends string, GivenState>(
+    statement: (tokens: any) => string,
+    variables: VariableMap
   ) =>
   <GivenDeps extends RequiredOrOptional<GivenState>>(dependencies: {
     given: GivenDeps;
   }) => ({
     step: addStep<
       GivenInput<Variables, Restrict<GivenState, GivenDeps>>,
-      GivenOutput<GivenState>
+      GivenOutput<GivenState>,
+      Expr
     >(
       statement,
       GIVEN,
       { ...dependencies, when: {}, then: {} } as FullDependencies,
-      parsers
+      variables
     ),
   });
 
-const givenParsers =
-  <Variables extends any[], GivenState>(
-    statement: (...args: any[]) => string
-  ) =>
-  <Parsers extends { [K in keyof Variables]: Parser<Variables[K]> }>(
-    parsers: Parsers
-  ) => ({
-    dependencies: givenDependencies<Variables, GivenState>(
-      statement,
-      parsers as unknown as Parser<any>[]
-    ),
-    step: addStep<GivenInput<Variables, never>, GivenOutput<GivenState>>(
-      statement,
-      GIVEN,
-      undefined,
-      parsers as unknown as Parser<any>[]
-    ),
+// The variable chain: `.variables({name: parser}).statement(v => ...)`. The
+// map fixes the variable names and (through each parser) their types; the
+// statement interpolates opaque tokens; the step function receives `variables`
+// as a name-keyed object. `Expr` captures the statement's template type so the
+// registered step's `expression` is a `${string}`-holed literal type.
+const givenVariables =
+  <GivenState>() =>
+  <Map extends VariableMap>(variables: Map) => ({
+    statement: <Expr extends string>(
+      statement: (tokens: VariableTokens<Map>) => Expr
+    ) => ({
+      dependencies: givenDependencies<VariablesOf<Map>, Expr, GivenState>(
+        statement,
+        variables
+      ),
+      step: addStep<
+        GivenInput<VariablesOf<Map>, never>,
+        GivenOutput<GivenState>,
+        Expr
+      >(statement, GIVEN, undefined, variables),
+    }),
   });
 
+// A statement with no variables is a plain string; `Expr` keeps its exact
+// literal type on the registered step's `expression`.
 const givenStatement =
   <GivenState>() =>
-  <Statement extends ((...args: [...any]) => string) | string>(
-    statement: Statement
-  ) => {
-    const normalizedStatement: (...args: any[]) => string = isString(statement)
-      ? () => statement
-      : (statement as (...args: any[]) => string);
-
-    type Variables = Statement extends string ? [] : GetFunctionArgs<Statement>;
+  <Expr extends string>(statement: Expr) => {
+    const statementFn = () => statement;
     return {
-      dependencies: givenDependencies<Variables, GivenState>(
-        normalizedStatement
+      dependencies: givenDependencies<NoVariables, Expr, GivenState>(
+        statementFn,
+        {}
       ),
-      parsers: givenParsers<Variables, GivenState>(normalizedStatement),
-      step: addStep<GivenInput<Variables, never>, GivenOutput<GivenState>>(
-        normalizedStatement,
-        GIVEN
-      ),
+      step: addStep<
+        GivenInput<NoVariables, never>,
+        GivenOutput<GivenState>,
+        Expr
+      >(statementFn, GIVEN, undefined, {}),
     };
   };
 
 export const givenBuilder = <GivenState>() => ({
   statement: givenStatement<GivenState>(),
+  variables: givenVariables<GivenState>(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,13 @@ export {
 
 export type { Parser };
 export type {
+  NoVariables,
+  Variable,
+  VariableMap,
+  VariableTokens,
+  VariablesOf,
+} from "./variables";
+export type {
   ScenarioInfo,
   PlainHookFn,
   ScenarioHookFn,

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,10 +2,18 @@ import { givenBuilder } from "./given";
 import { thenBuilder } from "./then";
 import { whenBuilder } from "./when";
 
+/**
+ * Pre-bound builders for one world type. Each entry is callable with a plain
+ * string statement (`Given("a user")`) and carries the named-variable entry
+ * point as a property (`Given.variables({...}).statement(v => ...)`).
+ */
 export const createBuilders = <GivenState, WhenState, ThenState>() => {
+  const given = givenBuilder<GivenState>();
+  const when = whenBuilder<GivenState, WhenState>();
+  const then = thenBuilder<GivenState, WhenState, ThenState>();
   return {
-    Given: givenBuilder<GivenState>().statement,
-    When: whenBuilder<GivenState, WhenState>().statement,
-    Then: thenBuilder<GivenState, WhenState, ThenState>().statement,
+    Given: given,
+    When: when,
+    Then: then,
   };
 };

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -17,9 +17,14 @@
  * variable type. `booleanParser` has no built-in equivalent, so it is a genuine
  * custom parameter type whose `parse` runs at match time.
  */
-export type Parser<T> = {
-  /** Parameter-type name; the step expression uses `{name}` as the placeholder. */
-  name: string;
+export type Parser<T, Name extends string = string> = {
+  /**
+   * Parameter-type name; the step expression uses `{name}` as the placeholder.
+   * Declaring it as a literal type (`Parser<Color, "color">`) lets the builder
+   * surface the placeholder in editor hovers on named variables — the default
+   * `string` keeps loosely-typed parsers working, at the cost of that hint.
+   */
+  name: Name;
   /** How cucumber-expressions recognises the value in the step text. */
   regexp: RegExp | RegExp[];
   /** Transform the matched text into the typed value. */
@@ -27,7 +32,7 @@ export type Parser<T> = {
 };
 
 /** Matches a quoted string (`{string}`) and strips the surrounding quotes. */
-export const stringParser: Parser<string> = {
+export const stringParser: Parser<string, "string"> = {
   name: "string",
   regexp: [/"([^"\\]*(\\.[^"\\]*)*)"/, /'([^'\\]*(\\.[^'\\]*)*)'/],
   parse: value => {
@@ -37,14 +42,14 @@ export const stringParser: Parser<string> = {
 };
 
 /** Matches an unquoted integer (`{int}`). */
-export const intParser: Parser<number> = {
+export const intParser: Parser<number, "int"> = {
   name: "int",
   regexp: /-?\d+/,
   parse: value => parseInt(value, 10),
 };
 
 /** Matches an unquoted floating point number (`{float}`). */
-export const numberParser: Parser<number> = {
+export const numberParser: Parser<number, "float"> = {
   name: "float",
   regexp: /-?\d*\.?\d+/,
   parse: value => parseFloat(value),
@@ -55,7 +60,7 @@ export const numberParser: Parser<number> = {
  * boolean. Unlike the others this is a genuine custom parameter type — cucumber
  * has no built-in `boolean` — so its `regexp`/`parse` are what the matcher uses.
  */
-export const booleanParser: Parser<boolean> = {
+export const booleanParser: Parser<boolean, "boolean"> = {
   name: "boolean",
   regexp: /true|false/,
   parse: value => value === "true",

--- a/src/then.ts
+++ b/src/then.ts
@@ -2,14 +2,17 @@
 
 import {
   FullDependencies,
-  GetFunctionArgs,
-  isString,
   RequiredOrOptional,
   Restrict,
   StepType,
 } from "./builderTypeUtils";
 import { addStep } from "./common";
-import { Parser } from "./parsers";
+import {
+  NoVariables,
+  VariableMap,
+  VariablesOf,
+  VariableTokens,
+} from "./variables";
 
 const THEN: StepType = "then";
 
@@ -25,10 +28,11 @@ type ThenInput<Variables, Given, When, Then> = {
 type ThenOutput<ThenState> =
   Partial<ThenState> | Promise<Partial<ThenState>> | void | Promise<void>;
 
+// Shared dependencies stage for both entry styles; see given.ts for the shape.
 const thenDependencies =
-  <Variables, GivenState, WhenState, ThenState>(
-    statement: (...args: any[]) => string,
-    parsers?: Parser<any>[]
+  <Variables, Expr extends string, GivenState, WhenState, ThenState>(
+    statement: (tokens: any) => string,
+    variables: VariableMap
   ) =>
   <
     GivenDeps extends RequiredOrOptional<GivenState>,
@@ -46,7 +50,8 @@ const thenDependencies =
         Restrict<WhenState, WhenDeps>,
         Restrict<ThenState, ThenDeps>
       >,
-      ThenOutput<ThenState>
+      ThenOutput<ThenState>,
+      Expr
     >(
       statement,
       THEN,
@@ -55,54 +60,56 @@ const thenDependencies =
         when: dependencies.when ?? {},
         then: dependencies.then ?? {},
       } as FullDependencies,
-      parsers
+      variables
     ),
   });
 
-const thenParsers =
-  <Variables extends any[], GivenState, WhenState, ThenState>(
-    statement: (...args: any[]) => string
-  ) =>
-  <Parsers extends { [K in keyof Variables]: Parser<Variables[K]> }>(
-    parsers: Parsers
-  ) => ({
-    dependencies: thenDependencies<Variables, GivenState, WhenState, ThenState>(
-      statement,
-      parsers as unknown as Parser<any>[]
-    ),
-    step: addStep<
-      ThenInput<Variables, never, never, never>,
-      ThenOutput<ThenState>
-    >(statement, THEN, undefined, parsers as unknown as Parser<any>[]),
-  });
-
-const thenStatement =
+// The variable chain: `.variables({name: parser}).statement(v => ...)`; see
+// given.ts for the pattern.
+const thenVariables =
   <GivenState, WhenState, ThenState>() =>
-  <Statement extends ((...args: [...any]) => string) | string>(
-    statement: Statement
-  ) => {
-    const normalizedStatement: (...args: any[]) => string = isString(statement)
-      ? () => statement
-      : (statement as (...args: any[]) => string);
-
-    type Variables = Statement extends string ? [] : GetFunctionArgs<Statement>;
-    return {
+  <Map extends VariableMap>(variables: Map) => ({
+    statement: <Expr extends string>(
+      statement: (tokens: VariableTokens<Map>) => Expr
+    ) => ({
       dependencies: thenDependencies<
-        Variables,
+        VariablesOf<Map>,
+        Expr,
         GivenState,
         WhenState,
         ThenState
-      >(normalizedStatement),
-      parsers: thenParsers<Variables, GivenState, WhenState, ThenState>(
-        normalizedStatement
-      ),
+      >(statement, variables),
       step: addStep<
-        ThenInput<Variables, never, never, never>,
-        ThenOutput<ThenState>
-      >(normalizedStatement, THEN),
+        ThenInput<VariablesOf<Map>, never, never, never>,
+        ThenOutput<ThenState>,
+        Expr
+      >(statement, THEN, undefined, variables),
+    }),
+  });
+
+// A statement with no variables is a plain string; `Expr` keeps its exact
+// literal type on the registered step's `expression`.
+const thenStatement =
+  <GivenState, WhenState, ThenState>() =>
+  <Expr extends string>(statement: Expr) => {
+    const statementFn = () => statement;
+    return {
+      dependencies: thenDependencies<
+        NoVariables,
+        Expr,
+        GivenState,
+        WhenState,
+        ThenState
+      >(statementFn, {}),
+      step: addStep<
+        ThenInput<NoVariables, never, never, never>,
+        ThenOutput<ThenState>,
+        Expr
+      >(statementFn, THEN, undefined, {}),
     };
   };
 
 export const thenBuilder = <GivenState, WhenState, ThenState>() => ({
   statement: thenStatement<GivenState, WhenState, ThenState>(),
+  variables: thenVariables<GivenState, WhenState, ThenState>(),
 });

--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { intParser, stringParser } from "./parsers";
+import { renderNamedExpression, VariableTokens } from "./variables";
+
+describe("renderNamedExpression", () => {
+  it("renders each parser's placeholder and records interpolation order", () => {
+    const { expression, order } = renderNamedExpression(
+      (v: VariableTokens<{ amount: typeof intParser }>) =>
+        `I deposit ${v.amount}`,
+      { amount: intParser }
+    );
+    expect(expression).toBe("I deposit {int}");
+    expect(order).toEqual(["amount"]);
+  });
+
+  it("orders by interpolation position, not declaration order", () => {
+    const { expression, order } = renderNamedExpression(
+      (v: Record<string, unknown>) => `pay ${v.currency} ${v.amount}`,
+      { amount: intParser, currency: stringParser }
+    );
+    expect(expression).toBe("pay {string} {int}");
+    expect(order).toEqual(["currency", "amount"]);
+  });
+
+  it("handles statements with no variables", () => {
+    const { expression, order } = renderNamedExpression(() => "I started", {});
+    expect(expression).toBe("I started");
+    expect(order).toEqual([]);
+  });
+
+  it("throws when a declared variable is never interpolated", () => {
+    expect(() =>
+      renderNamedExpression(() => "I started", { amount: intParser })
+    ).toThrow(/"amount" is declared .* never interpolated/);
+  });
+
+  it("throws when a variable is interpolated more than once", () => {
+    expect(() =>
+      renderNamedExpression(
+        (v: Record<string, unknown>) => `between ${v.amount} and ${v.amount}`,
+        { amount: intParser }
+      )
+    ).toThrow(/"amount" is interpolated more than once/);
+  });
+});

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Parser } from "./parsers";
+
+/**
+ * Named-variable declarations for a step: each key is a variable name, each
+ * value the parser that recognises and coerces it. Declared via the builder's
+ * `.variables({...})` entry point, this map is the single source of truth for
+ * a step's variables — their names, their order-independent identity, and
+ * (through each parser's `parse` return type) their TypeScript types.
+ */
+export type VariableMap = Record<string, Parser<any>>;
+
+declare const variableTokenBrand: unique symbol;
+
+/**
+ * Interpolation-only placeholder for a step variable: matches `{Name}` in the
+ * step text and resolves to a `T` in the step function's `variables`.
+ *
+ * Handed to a named statement function, one per declared variable.
+ * Interpolating it into the statement template
+ * (`` v => `a user named ${v.userName}` ``) is its only legal use: at
+ * registration time its `toString()` renders the parser's cucumber-expression
+ * placeholder (`{string}`, `{int}`, `{color}`, …) and records the
+ * interpolation order, which is how captured values are mapped back to
+ * variable *names* at run time. The brand makes any other use — arithmetic,
+ * string methods, comparisons — a type error. The `placeholder` property is a
+ * type-level hint only (it does not exist at runtime): both type arguments are
+ * visible on hover, so a statement author can see what the variable matches
+ * and what their step will receive.
+ */
+export type Variable<T, Name extends string = string> = {
+  /** The cucumber-expression placeholder this variable renders as. Type-level only. */
+  readonly placeholder: `{${Name}}`;
+  readonly [variableTokenBrand]: T;
+};
+
+/** The token object a named statement function receives: one token per declared variable. */
+export type VariableTokens<Map extends VariableMap> = {
+  readonly [K in keyof Map]: Map[K] extends Parser<infer T, infer Name>
+    ? Variable<T, Name>
+    : never;
+};
+
+/**
+ * The named `variables` object a step function receives: each declared
+ * variable, typed by its parser's `parse` return type.
+ */
+export type VariablesOf<Map extends VariableMap> = {
+  [K in keyof Map]: Map[K] extends Parser<infer T> ? T : never;
+};
+
+/**
+ * The `variables` type of a step whose statement declares none (a plain string
+ * statement): an empty object, so any property access is a type error.
+ */
+export type NoVariables = Record<never, never>;
+
+/**
+ * Render a named statement into its cucumber expression. The statement is
+ * called exactly once with a token per declared variable; each token's
+ * `toString()` emits the parser's placeholder and appends the variable's name
+ * to `order`, so the returned `order` is the positional layout of the
+ * expression's capture groups. The runtime uses it to turn the matcher's
+ * positional captures back into a named object.
+ *
+ * Validated eagerly (at registration, not at match time): every declared
+ * variable must be interpolated exactly once, so the positional ↔ named
+ * mapping is total and unambiguous.
+ */
+export const renderNamedExpression = (
+  statement: (tokens: any) => string,
+  variables: VariableMap
+): { expression: string; order: string[] } => {
+  const order: string[] = [];
+  const tokens: Record<string, unknown> = {};
+  for (const name of Object.keys(variables)) {
+    tokens[name] = {
+      toString: () => {
+        order.push(name);
+        return `{${variables[name].name}}`;
+      },
+    };
+  }
+  const expression = statement(tokens);
+  const seen = new Set<string>();
+  for (const name of order) {
+    if (seen.has(name)) {
+      throw new Error(
+        `Variable "${name}" is interpolated more than once in statement "${expression}". ` +
+          `Each declared variable must appear exactly once.`
+      );
+    }
+    seen.add(name);
+  }
+  for (const name of Object.keys(variables)) {
+    if (!seen.has(name)) {
+      throw new Error(
+        `Variable "${name}" is declared in .variables() but never interpolated ` +
+          `in statement "${expression}".`
+      );
+    }
+  }
+  return { expression, order };
+};

--- a/src/when.ts
+++ b/src/when.ts
@@ -2,14 +2,17 @@
 
 import {
   FullDependencies,
-  GetFunctionArgs,
-  isString,
   RequiredOrOptional,
   Restrict,
   StepType,
 } from "./builderTypeUtils";
 import { addStep } from "./common";
-import { Parser } from "./parsers";
+import {
+  NoVariables,
+  VariableMap,
+  VariablesOf,
+  VariableTokens,
+} from "./variables";
 
 const WHEN: StepType = "when";
 
@@ -23,10 +26,11 @@ type WhenInput<Variables, Given, When> = {
 };
 type WhenOutput<WhenState> = Partial<WhenState> | Promise<Partial<WhenState>>;
 
+// Shared dependencies stage for both entry styles; see given.ts for the shape.
 const whenDependencies =
-  <Variables, GivenState, WhenState>(
-    statement: (...args: any[]) => string,
-    parsers?: Parser<any>[]
+  <Variables, Expr extends string, GivenState, WhenState>(
+    statement: (tokens: any) => string,
+    variables: VariableMap
   ) =>
   <
     GivenDeps extends RequiredOrOptional<GivenState>,
@@ -41,7 +45,8 @@ const whenDependencies =
         Restrict<GivenState, GivenDeps>,
         Restrict<WhenState, WhenDeps>
       >,
-      WhenOutput<WhenState>
+      WhenOutput<WhenState>,
+      Expr
     >(
       statement,
       WHEN,
@@ -50,53 +55,52 @@ const whenDependencies =
         when: dependencies.when ?? {},
         then: {},
       } as FullDependencies,
-      parsers
+      variables
     ),
   });
 
-const whenParsers =
-  <Variables extends any[], GivenState, WhenState>(
-    statement: (...args: any[]) => string
-  ) =>
-  <Parsers extends { [K in keyof Variables]: Parser<Variables[K]> }>(
-    parsers: Parsers
-  ) => ({
-    dependencies: whenDependencies<Variables, GivenState, WhenState>(
-      statement,
-      parsers as unknown as Parser<any>[]
-    ),
-    step: addStep<WhenInput<Variables, never, never>, WhenOutput<WhenState>>(
-      statement,
-      WHEN,
-      undefined,
-      parsers as unknown as Parser<any>[]
-    ),
+// The variable chain: `.variables({name: parser}).statement(v => ...)`; see
+// given.ts for the pattern.
+const whenVariables =
+  <GivenState, WhenState>() =>
+  <Map extends VariableMap>(variables: Map) => ({
+    statement: <Expr extends string>(
+      statement: (tokens: VariableTokens<Map>) => Expr
+    ) => ({
+      dependencies: whenDependencies<
+        VariablesOf<Map>,
+        Expr,
+        GivenState,
+        WhenState
+      >(statement, variables),
+      step: addStep<
+        WhenInput<VariablesOf<Map>, never, never>,
+        WhenOutput<WhenState>,
+        Expr
+      >(statement, WHEN, undefined, variables),
+    }),
   });
 
+// A statement with no variables is a plain string; `Expr` keeps its exact
+// literal type on the registered step's `expression`.
 const whenStatement =
   <GivenState, WhenState>() =>
-  <Statement extends ((...args: [...any]) => string) | string>(
-    statement: Statement
-  ) => {
-    const normalizedStatement: (...args: any[]) => string = isString(statement)
-      ? () => statement
-      : (statement as (...args: any[]) => string);
-
-    type Variables = Statement extends string ? [] : GetFunctionArgs<Statement>;
+  <Expr extends string>(statement: Expr) => {
+    const statementFn = () => statement;
     return {
-      dependencies: whenDependencies<Variables, GivenState, WhenState>(
-        normalizedStatement
+      dependencies: whenDependencies<NoVariables, Expr, GivenState, WhenState>(
+        statementFn,
+        {}
       ),
-      parsers: whenParsers<Variables, GivenState, WhenState>(
-        normalizedStatement
-      ),
-      step: addStep<WhenInput<Variables, never, never>, WhenOutput<WhenState>>(
-        normalizedStatement,
-        WHEN
-      ),
+      step: addStep<
+        WhenInput<NoVariables, never, never>,
+        WhenOutput<WhenState>,
+        Expr
+      >(statementFn, WHEN, undefined, {}),
     };
   };
 
 export const whenBuilder = <GivenState, WhenState>() => ({
   statement: whenStatement<GivenState, WhenState>(),
+  variables: whenVariables<GivenState, WhenState>(),
 });

--- a/test/combinedBuilderTests.ts
+++ b/test/combinedBuilderTests.ts
@@ -1,4 +1,5 @@
 import { createBuilders } from "../src/init";
+import { intParser } from "../src/parsers";
 import {
   SampleGivenState,
   SampleWhenState,
@@ -13,13 +14,13 @@ const { Given, When, Then } = createBuilders<
   SampleThenState
 >();
 
-Given("a user").step(() => {
+Given.statement("a user").step(() => {
   return {
     a: "user",
   };
 });
 
-When("a user does something")
+When.statement("a user does something")
   .dependencies({
     given: {
       a: "required",
@@ -31,7 +32,7 @@ When("a user does something")
     };
   });
 
-Then("we should see something")
+Then.statement("we should see something")
   .dependencies({
     when: {
       d: "required",
@@ -40,5 +41,19 @@ Then("we should see something")
   .step(({ when }) => {
     return {
       g: Number(when.d),
+    };
+  });
+
+// The pre-bound builders also carry the named-variable entry point
+When.variables({ count: intParser })
+  .statement(v => `a user does something ${v.count} times`)
+  .dependencies({
+    given: {
+      a: "required",
+    },
+  })
+  .step(({ variables: { count }, given }) => {
+    return {
+      e: `${given.a} happened ${count} times`,
     };
   });

--- a/test/givenCompilationTests.ts
+++ b/test/givenCompilationTests.ts
@@ -34,18 +34,23 @@ givenBuilder<SampleGivenState>()
     };
   });
 
-// Simple variables example
+// Variables example - variables arrive as a name-keyed object typed by each
+// parser's return type
 givenBuilder<SampleGivenState>()
-  .statement((v1: string, v2: number) => `Given a user ${v1} ${v2}`)
-  .step(({ variables: [v1, v2] }) => {
+  .variables({ v1: stringParser, v2: intParser })
+  .statement(v => `Given a user ${v.v1} ${v.v2}`)
+  .step(({ variables: { v1, v2 } }) => {
+    const name: string = v1;
+    const amount: number = v2;
     return {
-      b: `I love ${v1} ${v2}`,
+      b: `I love ${name} ${amount}`,
     };
   });
 
-// Complex example
+// Complex example - variables chain into dependencies
 givenBuilder<SampleGivenState>()
-  .statement((v1: string, v2: number) => `Given a user ${v1} ${v2}`)
+  .variables({ v1: stringParser, v2: intParser })
+  .statement(v => `Given a user ${v.v1} ${v.v2}`)
   .dependencies({
     given: {
       a: "required",
@@ -53,55 +58,31 @@ givenBuilder<SampleGivenState>()
       c: "required",
     },
   })
-  .step(({ variables: [v1, v2], given: { a, b, c } }) => {
+  .step(({ variables: { v1, v2 }, given: { a, b, c } }) => {
     return {
       b: `I love ${v1} ${v2} ${a} ${b} ${c}`,
     };
   });
 
-// Parsers example - variables keep their declared types and parsers must match
-givenBuilder<SampleGivenState>()
-  .statement((v1: string, v2: number) => `Given a user ${v1} ${v2}`)
-  .parsers([stringParser, intParser])
-  .step(({ variables: [v1, v2] }) => {
-    const amount: number = v2;
-    return {
-      b: `I love ${v1} ${amount}`,
-    };
-  });
+// A string statement keeps its exact literal type on `expression`
+const stringMeta = givenBuilder<SampleGivenState>()
+  .statement("Given a user")
+  .step(() => ({ a: "user" }));
+export const exactExpression: "Given a user" = stringMeta.expression;
 
-// Parsers can chain into dependencies
-givenBuilder<SampleGivenState>()
-  .statement((v1: string, v2: number) => `Given a user ${v1} ${v2}`)
-  .parsers([stringParser, intParser])
-  .dependencies({ given: { a: "required" } })
-  .step(({ variables: [v1, v2], given: { a } }) => {
-    return {
-      b: `I love ${v1} ${v2} ${a}`,
-    };
-  });
+// A token statement keeps a `${string}`-holed template type on `expression`
+const namedMeta = givenBuilder<SampleGivenState>()
+  .variables({ v1: stringParser })
+  .statement(v => `Given a user ${v.v1}`)
+  .step(({ variables: { v1 } }) => ({ b: v1 }));
+export const templateExpression: `Given a user ${string}` =
+  namedMeta.expression;
 
 // ----- Should not compile section ----
 
 givenBuilder<SampleGivenState>()
-  .statement((v1: string, v2: number) => `Given a user ${v1} ${v2}`)
-  // @ts-expect-error - intParser produces number but v1 is declared as a string
-  .parsers([intParser, intParser])
-  .step(({ variables: [v1, v2] }) => {
-    return {
-      b: `I love ${v1} ${v2}`,
-    };
-  });
-
-givenBuilder<SampleGivenState>()
-  .statement((v1: string, v2: number) => `Given a user ${v1} ${v2}`)
-  // @ts-expect-error - too few parsers for the declared variables
-  .parsers([stringParser])
-  .step(({ variables: [v1, v2] }) => {
-    return {
-      b: `I love ${v1} ${v2}`,
-    };
-  });
+  // @ts-expect-error - function statements are gone; declare variables with .variables()
+  .statement((v1: string) => `Given a user ${v1}`);
 
 // @ts-expect-error - Should not compile without a statement
 givenBuilder<SampleGivenState>().step(() => {
@@ -110,16 +91,6 @@ givenBuilder<SampleGivenState>().step(() => {
   };
 });
 
-givenBuilder<SampleGivenState>()
-  .statement(() => "Given a user")
-  // @ts-expect-error - Should not compile since no variables are declared
-  .step(({ variables: [v1, v2] }) => {
-    return {
-      a: `I love ${v1} ${v2}`,
-    };
-  });
-
-// TODO: Currently resolves variables to `any[]` which is incorrect
 givenBuilder<SampleGivenState>()
   .statement("Given a user")
   // @ts-expect-error - Should not compile since no variables are declared
@@ -130,13 +101,62 @@ givenBuilder<SampleGivenState>()
   });
 
 givenBuilder<SampleGivenState>()
-  .statement(
-    (v1: string, v2: number, v3: boolean) => `Given a user ${v1} ${v2} ${v3}`
-  )
-  // @ts-expect-error - Should not compile since the number of variables exceeds the number declared
-  .step(({ variables: [v1, v2, v3, v4] }) => {
+  .statement("Given a user")
+  // @ts-expect-error - Should not compile since no variables are declared
+  .step(({ variables: { v1 } }) => {
     return {
-      a: `I love ${v1} ${v2} ${v3} ${v4}`,
+      a: `I love ${v1}`,
+    };
+  });
+
+givenBuilder<SampleGivenState>()
+  // @ts-expect-error - variables map values must be parsers
+  .variables({ v1: 42 })
+  .statement(v => `Given a user ${v.v1}`)
+  .step(() => {
+    return {
+      a: "user",
+    };
+  });
+
+givenBuilder<SampleGivenState>()
+  .variables({ v1: stringParser })
+  // @ts-expect-error - the statement can only interpolate declared variable names
+  .statement(v => `Given a user ${v.nope}`)
+  .step(({ variables: { v1 } }) => {
+    return {
+      b: `I love ${v1}`,
+    };
+  });
+
+givenBuilder<SampleGivenState>()
+  .variables({ v1: intParser })
+  // @ts-expect-error - tokens are opaque placeholders, not usable as values
+  .statement(v => `Given a user ${v.v1 * 2}`)
+  .step(({ variables: { v1 } }) => {
+    return {
+      b: `I love ${v1}`,
+    };
+  });
+
+givenBuilder<SampleGivenState>()
+  .variables({ v1: intParser })
+  .statement(v => `Given a user ${v.v1}`)
+  .step(({ variables: { v1 } }) => {
+    // @ts-expect-error - v1 came from intParser, so it is a number, not a string
+    const name: string = v1;
+    return {
+      b: `I love ${name}`,
+    };
+  });
+
+givenBuilder<SampleGivenState>()
+  .variables({ v1: stringParser })
+  .statement(v => `Given a user ${v.v1}`)
+  // @ts-expect-error - only declared variable names exist on `variables`
+  .step(({ variables: { v2 } }) => {
+    return {
+      b: `I love ${v2}`,
     };
   });
 

--- a/test/thenCompilationTests.ts
+++ b/test/thenCompilationTests.ts
@@ -1,4 +1,5 @@
 import { thenBuilder } from "../src/then";
+import { intParser, stringParser } from "../src/parsers";
 import {
   SampleGivenState,
   SampleThenState,
@@ -65,10 +66,11 @@ thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
     };
   });
 
-// Simple variables example
+// Variables example
 thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
-  .statement((v1: string, v2: number) => `Then we should see ${v1} ${v2} times`)
-  .step(({ variables: [v1, v2] }) => {
+  .variables({ v1: stringParser, v2: intParser })
+  .statement(v => `Then we should see ${v.v1} ${v.v2} times`)
+  .step(({ variables: { v1, v2 } }) => {
     return {
       i: { j: `Result ${v1} ${v2}` },
     };
@@ -76,7 +78,8 @@ thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
 
 // Complex example with all dependencies
 thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
-  .statement((v1: string, v2: number) => `Then we should see ${v1} ${v2} times`)
+  .variables({ v1: stringParser, v2: intParser })
+  .statement(v => `Then we should see ${v.v1} ${v.v2} times`)
   .dependencies({
     given: {
       a: "required",
@@ -93,7 +96,7 @@ thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
   })
   .step(
     ({
-      variables: [v1, v2],
+      variables: { v1, v2 },
       given: { a, b },
       when: { d, e },
       then: { g, h },
@@ -104,7 +107,22 @@ thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
     }
   );
 
+// A string statement keeps its exact literal type on `expression`
+const stringMeta = thenBuilder<
+  SampleGivenState,
+  SampleWhenState,
+  SampleThenState
+>()
+  .statement("Then we should see something")
+  .step(() => {});
+export const exactExpression: "Then we should see something" =
+  stringMeta.expression;
+
 // ----- Should not compile section ----
+
+thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
+  // @ts-expect-error - function statements are gone; declare variables with .variables()
+  .statement((v1: string) => `Then we should see ${v1}`);
 
 // @ts-expect-error - Should not compile without a statement
 thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>().step(() => {
@@ -112,15 +130,6 @@ thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>().step(() => {
     i: { j: "result" },
   };
 });
-
-thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
-  .statement(() => "Then we should see something")
-  // @ts-expect-error - Should not compile since no variables are declared
-  .step(({ variables: [v1, v2] }) => {
-    return {
-      i: { j: `Result ${v1} ${v2}` },
-    };
-  });
 
 thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
   .statement("Then we should see something")
@@ -132,14 +141,22 @@ thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
   });
 
 thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
-  .statement(
-    (v1: string, v2: number, v3: boolean) =>
-      `Then we should see ${v1} ${v2} ${v3}`
-  )
-  // @ts-expect-error - Should not compile since the number of variables exceeds the number declared
-  .step(({ variables: [v1, v2, v3, v4] }) => {
+  .variables({ v1: stringParser })
+  // @ts-expect-error - the statement can only interpolate declared variable names
+  .statement(v => `Then we should see ${v.nope}`)
+  .step(({ variables: { v1 } }) => {
     return {
-      i: { j: `Result ${v1} ${v2} ${v3} ${v4}` },
+      i: { j: `Result ${v1}` },
+    };
+  });
+
+thenBuilder<SampleGivenState, SampleWhenState, SampleThenState>()
+  .variables({ v1: stringParser })
+  .statement(v => `Then we should see ${v.v1}`)
+  // @ts-expect-error - only declared variable names exist on `variables`
+  .step(({ variables: { v2 } }) => {
+    return {
+      i: { j: `Result ${v2}` },
     };
   });
 

--- a/test/whenCompilationTests.ts
+++ b/test/whenCompilationTests.ts
@@ -1,4 +1,5 @@
 import { whenBuilder } from "../src/when";
+import { intParser, stringParser } from "../src/parsers";
 import { SampleGivenState, SampleWhenState } from "./testUtils";
 
 // Simplest possible example
@@ -47,10 +48,11 @@ whenBuilder<SampleGivenState, SampleWhenState>()
     };
   });
 
-// Simple variables example
+// Variables example
 whenBuilder<SampleGivenState, SampleWhenState>()
-  .statement((v1: string, v2: number) => `When a user does ${v1} ${v2} times`)
-  .step(({ variables: [v1, v2] }) => {
+  .variables({ v1: stringParser, v2: intParser })
+  .statement(v => `When a user does ${v.v1} ${v.v2} times`)
+  .step(({ variables: { v1, v2 } }) => {
     return {
       e: `Action ${v1} ${v2}`,
     };
@@ -58,7 +60,8 @@ whenBuilder<SampleGivenState, SampleWhenState>()
 
 // Complex example with both dependencies
 whenBuilder<SampleGivenState, SampleWhenState>()
-  .statement((v1: string, v2: number) => `When a user does ${v1} ${v2} times`)
+  .variables({ v1: stringParser, v2: intParser })
+  .statement(v => `When a user does ${v.v1} ${v.v2} times`)
   .dependencies({
     given: {
       a: "required",
@@ -69,13 +72,24 @@ whenBuilder<SampleGivenState, SampleWhenState>()
       e: "optional",
     },
   })
-  .step(({ variables: [v1, v2], given: { a, b }, when: { d, e } }) => {
+  .step(({ variables: { v1, v2 }, given: { a, b }, when: { d, e } }) => {
     return {
       e: `Action ${v1} ${v2} with ${a} ${b} ${d} ${e}`,
     };
   });
 
+// A string statement keeps its exact literal type on `expression`
+const stringMeta = whenBuilder<SampleGivenState, SampleWhenState>()
+  .statement("When a user does something")
+  .step(() => ({ e: "action" }));
+export const exactExpression: "When a user does something" =
+  stringMeta.expression;
+
 // ----- Should not compile section ----
+
+whenBuilder<SampleGivenState, SampleWhenState>()
+  // @ts-expect-error - function statements are gone; declare variables with .variables()
+  .statement((v1: string) => `When a user does ${v1}`);
 
 // @ts-expect-error - Should not compile without a statement
 whenBuilder<SampleGivenState, SampleWhenState>().step(() => {
@@ -83,15 +97,6 @@ whenBuilder<SampleGivenState, SampleWhenState>().step(() => {
     a: "action",
   };
 });
-
-whenBuilder<SampleGivenState, SampleWhenState>()
-  .statement(() => "When a user does something")
-  // @ts-expect-error - Should not compile since no variables are declared
-  .step(({ variables: [v1, v2] }) => {
-    return {
-      a: `Action ${v1} ${v2}`,
-    };
-  });
 
 whenBuilder<SampleGivenState, SampleWhenState>()
   .statement("When a user does something")
@@ -103,14 +108,22 @@ whenBuilder<SampleGivenState, SampleWhenState>()
   });
 
 whenBuilder<SampleGivenState, SampleWhenState>()
-  .statement(
-    (v1: string, v2: number, v3: boolean) =>
-      `When a user does ${v1} ${v2} ${v3}`
-  )
-  // @ts-expect-error - Should not compile since the number of variables exceeds the number declared
-  .step(({ variables: [v1, v2, v3, v4] }) => {
+  .variables({ v1: stringParser })
+  // @ts-expect-error - the statement can only interpolate declared variable names
+  .statement(v => `When a user does ${v.nope}`)
+  .step(({ variables: { v1 } }) => {
     return {
-      a: `Action ${v1} ${v2} ${v3} ${v4}`,
+      e: `Action ${v1}`,
+    };
+  });
+
+whenBuilder<SampleGivenState, SampleWhenState>()
+  .variables({ v1: stringParser })
+  .statement(v => `When a user does ${v.v1}`)
+  // @ts-expect-error - only declared variable names exist on `variables`
+  .step(({ variables: { v2 } }) => {
+    return {
+      e: `Action ${v2}`,
     };
   });
 
@@ -149,7 +162,7 @@ whenBuilder<SampleGivenState, SampleWhenState>()
   .statement("When a user does something")
   .dependencies({ when: { e: "optional" } })
   .step(({ when }) => {
-    // @ts-expect-error - Should not compile since a is optional and can be undefined
+    // @ts-expect-error - Should not compile since e is optional and can be undefined
     const strictE: string = when.e;
     return {
       f: [strictE.length],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "Node",
     "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
PR that flips the old pattern on its head a bit. Instead of defining parsers for variables after the statement, we define the variables **and** their parsers before the statement. This had some benefits, including that it will allow us to build the entire step text at compile time. This is a big win for the analyzer, the interactive test runner, and other tools we want to build because it will be much faster and more deterministic to discover steps.

Additionally, it removes some easy footguns that were present with array-indexed variables. For example, transposing two variable names won't result in unexpected results.